### PR TITLE
Move DI mechanics out of PostgresDatabase

### DIFF
--- a/src/Beckett/ServiceCollectionExtensions.cs
+++ b/src/Beckett/ServiceCollectionExtensions.cs
@@ -7,7 +7,7 @@ namespace Beckett;
 
 public static class ServiceCollectionExtensions
 {
-    public static void AddBeckett(this IServiceCollection services, Action<BeckettOptions> configure)
+    public static IServiceCollection AddBeckett(this IServiceCollection services, Action<BeckettOptions> configure)
     {
         var options = new BeckettOptions();
 
@@ -26,6 +26,8 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IEventStore, EventStore>();
 
         services.AddHostedService<BackgroundService>();
+
+        return services;
     }
 
     private static void RunConfigurators(IServiceCollection services, BeckettOptions options)

--- a/src/Beckett/Storage/Postgres/IPostgresDatabase.cs
+++ b/src/Beckett/Storage/Postgres/IPostgresDatabase.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.DependencyInjection;
 using Npgsql;
 
 namespace Beckett.Storage.Postgres;
@@ -8,23 +7,7 @@ public interface IPostgresDatabase
     NpgsqlConnection CreateConnection();
 }
 
-public class PostgresDatabase : IPostgresDatabase
+public class PostgresDatabase(NpgsqlDataSource dataSource) : IPostgresDatabase
 {
-    private readonly NpgsqlDataSource _dataSource;
-
-    public PostgresDatabase(BeckettOptions options, IServiceProvider serviceProvider)
-    {
-        if (options.Postgres.DataSource != null)
-        {
-            _dataSource = options.Postgres.DataSource;
-        }
-
-        var dataSource = serviceProvider.GetService<NpgsqlDataSource>();
-
-        _dataSource = dataSource ?? throw new InvalidOperationException(
-            "Registered NpgsqlDataSource not found - please register one using AddNpgsqlDataSource from the Npgsql.DependencyInjection package, provide a configured instance via UseDataSource, or call UseConnectionString"
-        );
-    }
-
-    public NpgsqlConnection CreateConnection() => _dataSource.CreateConnection();
+    public NpgsqlConnection CreateConnection() => dataSource.CreateConnection();
 }

--- a/src/Beckett/Storage/Postgres/PostgresOptions.cs
+++ b/src/Beckett/Storage/Postgres/PostgresOptions.cs
@@ -38,7 +38,7 @@ public class PostgresOptions
             SearchPath = Schema
         };
 
-        DataSource = new NpgsqlDataSourceBuilder(builder.ConnectionString).Build();
+        DataSource = new NpgsqlDataSourceBuilder(builder.ConnectionString).AddBeckett().Build();
     }
 
     public void UseNotifications(TimeSpan? keepAlive = null)


### PR DESCRIPTION
Allow the consumer to create an instance of PostgresDatabase without involving
the service provider.

Also, register types when creating datasource from connection string.