### PR TITLE
Respect UnknownMessageTypePolicy

### DIFF
--- a/src/Beckett/Messages/MessageTypeMap.cs
+++ b/src/Beckett/Messages/MessageTypeMap.cs
@@ -61,17 +61,9 @@ public class MessageTypeMap(
     {
         var messageType = _nameToTypeMap.GetOrAdd(
             name,
-            typeName =>
-            {
-                if (!options.AllowDynamicTypeMapping)
-                {
-                    throw new Exception(
-                        $"{nameof(MessageOptions.AllowDynamicTypeMapping)} is disabled - you must add a type mapping for {name}"
-                    );
-                }
-
-                return messageTypeProvider.FindMatchFor(x => MatchCriteria(x, typeName));
-            }
+            typeName => options.AllowDynamicTypeMapping
+                ? messageTypeProvider.FindMatchFor(x => MatchCriteria(x, typeName))
+                : null
         );
 
         if (messageType != null)


### PR DESCRIPTION
[This commit](https://github.com/mattburton/beckett/commit/ecc6b6d0e4f6dc7387ab6451bb6f4f2ae19afac5) added support for ignoring unknown message types,
but it doesn't seem like it was allowed to work because the GetOrAdd
would throw an exception if a message type was not registered and
`options.AllowDynamicTypeMapping` was `false`.

Instead, we will now store `null` as the mapped type, and respond based
on the configured `UnknownMessageTypePolicy`.