### PR TITLE
Improve timestamp displays in the dashboard

### DIFF
--- a/src/Beckett.Dashboard/Layout.cshtml
+++ b/src/Beckett.Dashboard/Layout.cshtml
@@ -35,6 +35,14 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
           integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
           crossorigin="anonymous"></script>
+  <script type="text/javascript">
+    window.addEventListener("load", () => {
+      document.querySelectorAll(".timestamp").forEach((element) => {
+        element.innerText = new Date(Date.parse(element.innerText)).toLocaleString()
+        element.style = "display: inline";
+      });
+    });
+  </script>
 </body>
 </html>
 

--- a/src/Beckett.Dashboard/MessageStore/Layout.cshtml
+++ b/src/Beckett.Dashboard/MessageStore/Layout.cshtml
@@ -40,11 +40,3 @@
 <div id="results">
   @RenderBody()
 </div>
-<script type="text/javascript">
-  window.addEventListener("load", () => {
-    document.querySelectorAll(".timestamp").forEach((element) => {
-      element.innerText = new Date(Date.parse(element.innerText)).toLocaleString()
-      element.classList.add("d-block");
-    });
-  });
-</script>

--- a/src/Beckett.Dashboard/MessageStore/Message.cshtml
+++ b/src/Beckett.Dashboard/MessageStore/Message.cshtml
@@ -29,7 +29,7 @@
   </ol>
 </nav>
 
-<div class="row mt-4 w-75 mx-auto">
+<div class="row mt-4 mx-auto">
   <div class="col-sm-8 mb-3 mb-sm-0">
     <div class="card ms-4" style="max-height: 75vh">
       <div class="card-header">
@@ -50,6 +50,7 @@
         Metadata
       </div>
       <ul class="list-group list-group-flush">
+        <li class="list-group-item">timestamp: <span class="timestamp">@Model.Message.Timestamp</span></li>
         @foreach (var item in Model.Message.Metadata)
         {
           if (item.Key == MessageConstants.Metadata.CausationId)

--- a/src/Beckett.Dashboard/MessageStore/Messages.cshtml
+++ b/src/Beckett.Dashboard/MessageStore/Messages.cshtml
@@ -3,6 +3,7 @@
 
 @{
   Layout = new Layout();
+  DateTimeOffset? previousTimestamp = null;
 }
 
 <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
@@ -27,7 +28,7 @@
   <thead>
     <tr>
       <th>Id</th>
-      <th>Stream Position</th>
+      <th style="width: 10em;">Stream Position</th>
       <th>Type</th>
       <th style="width: 20em;">Timestamp</th>
     </tr>
@@ -35,6 +36,10 @@
   <tbody>
   @foreach(var message in Model.Messages)
   {
+    var currentTimestamp = message.Timestamp;
+    var timeOffset = previousTimestamp.HasValue ? (currentTimestamp - previousTimestamp.Value).ToString(@"hh\:mm\:ss\.fff") : "";
+    previousTimestamp = currentTimestamp;
+
     <tr>
       <td>
         <a href="@Routes.Prefix/message-store/messages/@message.Id">@message.Id</a>
@@ -43,6 +48,10 @@
       <td>@message.Type</td>
       <td>
         <span class="timestamp">@message.Timestamp</span>
+        @if (!string.IsNullOrEmpty(timeOffset))
+        {
+        <small class="text-muted"> +@timeOffset</small>
+        }
       </td>
     </tr>
   }

--- a/src/Beckett/Dashboard/MessageStore/GetMessageResult.cs
+++ b/src/Beckett/Dashboard/MessageStore/GetMessageResult.cs
@@ -5,6 +5,7 @@ public record GetMessageResult(
     string Category,
     string StreamName,
     string Type,
+    DateTimeOffset Timestamp,
     string Data,
     Dictionary<string, object> Metadata
 );

--- a/src/Beckett/Dashboard/MessageStore/Queries/GetMessage.cs
+++ b/src/Beckett/Dashboard/MessageStore/Queries/GetMessage.cs
@@ -14,7 +14,7 @@ public class GetMessage(Guid id) : IPostgresDatabaseQuery<GetMessageResult?>
     )
     {
         command.CommandText = $@"
-            select {schema}.stream_category(stream_name) as category, stream_name, type, data, metadata
+            select {schema}.stream_category(stream_name) as category, stream_name, type, timestamp, data, metadata
             from {schema}.messages
             where id = $1
             and deleted = false
@@ -36,7 +36,7 @@ public class GetMessage(Guid id) : IPostgresDatabaseQuery<GetMessageResult?>
             return null;
         }
 
-        var metadata = JsonSerializer.Deserialize<Dictionary<string, object>>(reader.GetFieldValue<string>(4)) ??
+        var metadata = JsonSerializer.Deserialize<Dictionary<string, object>>(reader.GetFieldValue<string>(5)) ??
                        throw new InvalidOperationException($"Unable to deserialize metadata for message {id}");
 
         return !reader.HasRows
@@ -46,7 +46,8 @@ public class GetMessage(Guid id) : IPostgresDatabaseQuery<GetMessageResult?>
                 reader.GetFieldValue<string>(0),
                 reader.GetFieldValue<string>(1),
                 reader.GetFieldValue<string>(2),
-                reader.GetFieldValue<string>(3),
+                reader.GetFieldValue<DateTimeOffset>(3),
+                reader.GetFieldValue<string>(4),
                 metadata
             );
     }

--- a/src/Beckett/Dashboard/MessageStore/Queries/GetMessageByStreamPosition.cs
+++ b/src/Beckett/Dashboard/MessageStore/Queries/GetMessageByStreamPosition.cs
@@ -15,7 +15,7 @@ public class GetMessageByStreamPosition(string streamName, long streamPosition)
     )
     {
         command.CommandText = $@"
-            select id::text, {schema}.stream_category(stream_name) as category, stream_name, type, data, metadata
+            select id::text, {schema}.stream_category(stream_name) as category, stream_name, type, timestamp, data, metadata
             from {schema}.messages
             where stream_name = $1
             and stream_position = $2
@@ -40,7 +40,7 @@ public class GetMessageByStreamPosition(string streamName, long streamPosition)
             return null;
         }
 
-        var metadata = JsonSerializer.Deserialize<Dictionary<string, object>>(reader.GetFieldValue<string>(5)) ??
+        var metadata = JsonSerializer.Deserialize<Dictionary<string, object>>(reader.GetFieldValue<string>(6)) ??
                        throw new InvalidOperationException(
                            $"Unable to deserialize metadata for message at {streamName} and stream_position {streamPosition}"
                        );
@@ -52,7 +52,8 @@ public class GetMessageByStreamPosition(string streamName, long streamPosition)
                 reader.GetFieldValue<string>(1),
                 reader.GetFieldValue<string>(2),
                 reader.GetFieldValue<string>(3),
-                reader.GetFieldValue<string>(4),
+                reader.GetFieldValue<DateTimeOffset>(4),
+                reader.GetFieldValue<string>(5),
                 metadata
             );
     }


### PR DESCRIPTION
On the stream display page, show the time since the previous message:
![image](https://github.com/user-attachments/assets/00cd799a-51ff-42a0-9611-86a9bf2b9d02)

and then when you click into an individual message, show the timestamp in the Metadata section:
![image](https://github.com/user-attachments/assets/ac22da8c-3110-453d-bec1-aafc72bc3391)
