### PR TITLE
Checkpoint Processing - reduce database impact of notifications

### DIFF
--- a/db/migrations/001.sql
+++ b/db/migrations/001.sql
@@ -419,7 +419,7 @@ BEGIN
     NEW.process_at = now();
   END IF;
 
-  IF (NEW.process_at IS NOT NULL) THEN
+  IF (NEW.name != '$global' AND NEW.process_at IS NOT NULL) THEN
     PERFORM pg_notify('beckett:checkpoints', NEW.group_name);
   END IF;
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -198,7 +198,7 @@ $$;
 
 CREATE FUNCTION beckett.checkpoint_preprocessor() RETURNS trigger
     LANGUAGE plpgsql
-    AS $$
+    AS $_$
 BEGIN
   IF (TG_OP = 'UPDATE') THEN
     NEW.updated_at = now();
@@ -208,13 +208,13 @@ BEGIN
     NEW.process_at = now();
   END IF;
 
-  IF (NEW.process_at IS NOT NULL) THEN
+  IF (NEW.name != '$global' AND NEW.process_at IS NOT NULL) THEN
     PERFORM pg_notify('beckett:checkpoints', NEW.group_name);
   END IF;
 
   RETURN NEW;
 END;
-$$;
+$_$;
 
 
 --

--- a/db/versions/0.15.0.sql
+++ b/db/versions/0.15.0.sql
@@ -1,0 +1,19 @@
+CREATE OR REPLACE FUNCTION beckett.checkpoint_preprocessor() RETURNS trigger
+  LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF (TG_OP = 'UPDATE') THEN
+    NEW.updated_at = now();
+  END IF;
+
+  IF (NEW.status = 'active' AND NEW.process_at IS NULL AND NEW.stream_version > NEW.stream_position) THEN
+    NEW.process_at = now();
+  END IF;
+
+  IF (NEW.name != '$global' AND NEW.process_at IS NOT NULL) THEN
+    PERFORM pg_notify('beckett:checkpoints', NEW.group_name);
+  END IF;
+
+  RETURN NEW;
+END;
+$$;

--- a/db/versions/README.md
+++ b/db/versions/README.md
@@ -1,0 +1,4 @@
+# Database Migrations - Versions
+
+Until the release of V1 these scripts will track the migrations required to go from version to version. After V1 this
+folder will be removed and database changes will result in new migrations in the `migrations` folder.

--- a/src/Beckett/Subscriptions/ICheckpointConsumer.cs
+++ b/src/Beckett/Subscriptions/ICheckpointConsumer.cs
@@ -2,5 +2,5 @@ namespace Beckett.Subscriptions;
 
 public interface ICheckpointConsumer
 {
-    void StartPolling();
+    Task StartPolling(CancellationToken cancellationToken);
 }


### PR DESCRIPTION
When running a large number of nodes and / or a high concurrency configuration when a checkpoint notification arrives the previous design would result in every single checkpoint consumer being notified in each node that was running which results in a large hit on the database all at once as they all attempt to reserve a checkpoint to start processing.

This PR introduces a `System.Threading.Channels.Channel<T>` that is used as a queue to prevent this issue from happening - the number of active checkpoint consumers will reflect the number of available items in the channel. The channel is bounded so that back pressure is applied, with a max of `concurrency * 2` items allowed at any given time. The logic is as follows:

- run N consumers (where N is the concurrency setting for the subscription group) which are all reading from a shared channel
- when a Postgres notification is received or the polling interval has come due write an item to the channel
- only one consumer will be able to read each item, at which point it attempts to reserve a checkpoint to process
  - if there are no checkpoints available the consumer resumes waiting
- once the checkpoint is processed successfully write another item to the channel in case there is more work to do

The one caveat to this design is that if Postgres notifications are disabled then each polling cycle will result in initially processing one checkpoint only, as opposed to however many are available at that point in time for your concurrency configuration, but the idea is that it will quickly go from a single checkpoint to every consumer being active if there is enough work to do since the consumers will queue up more work after each checkpoint is processed and the load will get spread across all available consumers.

This PR also contains a fix for the `checkpoint_preprocessor` trigger - it was causing checkpoint notifications to be sent whenever the `$global` checkpoint for a subscription group was updated, which it should not be doing.

Lastly, in order to better serve pre-V1 users of the library there is a new `db/versions` folder containing example migrations between each version. Once V1 is released then new migrations will be added to the `migrations` folder for any future database versions.