### PR TITLE
Beckett context and tenant metadata support

### DIFF
--- a/db/migrations/001.sql
+++ b/db/migrations/001.sql
@@ -68,11 +68,12 @@ CREATE TABLE IF NOT EXISTS __schema__.messages_active PARTITION OF __schema__.me
 
 CREATE TABLE IF NOT EXISTS __schema__.messages_archived PARTITION OF __schema__.messages FOR VALUES IN (true);
 
-CREATE INDEX IF NOT EXISTS ix_messages_active_global_read_stream ON beckett.messages_active (transaction_id, global_position, archived);
+CREATE INDEX IF NOT EXISTS ix_messages_active_global_read_stream ON __schema__.messages_active (transaction_id, global_position, archived);
 
-CREATE INDEX IF NOT EXISTS ix_messages_active_stream_category ON __schema__.messages_active (__schema__.stream_category(stream_name));
+CREATE INDEX IF NOT EXISTS ix_messages_active_tenant_stream_category on __schema__.messages_active ((metadata ->> '$tenant'), beckett.stream_category(stream_name))
+  WHERE metadata ->> '$tenant' IS NOT NULL;
 
-CREATE INDEX IF NOT EXISTS ix_messages_active_correlation_id ON beckett.messages_active ((metadata ->> '$correlation_id'))
+CREATE INDEX IF NOT EXISTS ix_messages_active_correlation_id ON __schema__.messages_active ((metadata ->> '$correlation_id'))
   WHERE metadata ->> '$correlation_id' IS NOT NULL;
 
 CREATE OR REPLACE FUNCTION __schema__.stream_hash(

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1039,10 +1039,10 @@ CREATE INDEX ix_messages_active_global_read_stream ON beckett.messages_active US
 
 
 --
--- Name: ix_messages_active_stream_category; Type: INDEX; Schema: beckett; Owner: -
+-- Name: ix_messages_active_tenant_stream_category; Type: INDEX; Schema: beckett; Owner: -
 --
 
-CREATE INDEX ix_messages_active_stream_category ON beckett.messages_active USING btree (beckett.stream_category(stream_name));
+CREATE INDEX ix_messages_active_tenant_stream_category ON beckett.messages_active USING btree (((metadata ->> '$tenant'::text)), beckett.stream_category(stream_name)) WHERE ((metadata ->> '$tenant'::text) IS NOT NULL);
 
 
 --

--- a/db/versions/0.15.0.sql
+++ b/db/versions/0.15.0.sql
@@ -1,3 +1,8 @@
+DROP INDEX IF EXISTS beckett.ix_messages_active_stream_category;
+
+CREATE INDEX IF NOT EXISTS ix_messages_active_tenant_stream_category on beckett.messages_active ((metadata ->> '$tenant'), beckett.stream_category(stream_name))
+  WHERE metadata ->> '$tenant' IS NOT NULL;
+
 CREATE OR REPLACE FUNCTION beckett.checkpoint_preprocessor() RETURNS trigger
   LANGUAGE plpgsql
 AS $$

--- a/samples/TaskHub/API/Program.cs
+++ b/samples/TaskHub/API/Program.cs
@@ -21,7 +21,7 @@ try
 
     builder.Services.AddSerilog((_, configuration) => configuration.ReadFrom.Configuration(builder.Configuration));
 
-    await builder.AddTaskmasterDatabase();
+    await builder.AddTaskHubDatabase();
 
     builder.Services.AddBeckett().WithMessageTypesFrom(typeof(TaskList).Assembly);
 

--- a/samples/TaskHub/TaskHub/Infrastructure/Database/ServiceCollectionExtensions.cs
+++ b/samples/TaskHub/TaskHub/Infrastructure/Database/ServiceCollectionExtensions.cs
@@ -7,7 +7,7 @@ namespace TaskHub.Infrastructure.Database;
 
 public static class ServiceCollectionExtensions
 {
-    public static async Task AddTaskmasterDatabase(this IHostApplicationBuilder builder)
+    public static async Task AddTaskHubDatabase(this IHostApplicationBuilder builder)
     {
         var migrationsConnectionString = builder.Configuration.GetConnectionString("Migrations") ??
                                          throw new Exception("Missing Migrations connection string");

--- a/samples/TaskHub/Worker/Program.cs
+++ b/samples/TaskHub/Worker/Program.cs
@@ -17,7 +17,7 @@ try
 
     builder.Services.AddSerilog((_, configuration) => configuration.ReadFrom.Configuration(builder.Configuration));
 
-    await builder.AddTaskmasterDatabase();
+    await builder.AddTaskHubDatabase();
 
     builder.Services.AddBeckett(
         options => { options.WithSubscriptionGroup("TaskHub"); }
@@ -31,7 +31,6 @@ try
                 .AddBeckett()
                 .AddOtlpExporter(options => options.Endpoint = new Uri("http://localhost:4317"))
         );
-
 
     var host = builder.Build();
 

--- a/src/Beckett/BeckettContext.cs
+++ b/src/Beckett/BeckettContext.cs
@@ -1,0 +1,28 @@
+using System.Diagnostics;
+using Beckett.OpenTelemetry;
+
+namespace Beckett;
+
+public static class BeckettContext
+{
+    private const string DefaultTenant = "default";
+
+    public static string? GetCorrelationId() =>
+        Activity.Current?.GetBaggageItem(TelemetryConstants.Message.CorrelationId);
+
+    public static string GetTenant() =>
+        Activity.Current?.GetBaggageItem(TelemetryConstants.Message.Tenant) ?? DefaultTenant;
+
+    public static void SetCorrelationId(string correlationId)
+    {
+        Activity.Current?.AddBaggage(TelemetryConstants.Message.CorrelationId, correlationId);
+    }
+
+    public static void SetTenant(string? tenant)
+    {
+        Activity.Current?.AddBaggage(
+            TelemetryConstants.Message.Tenant,
+            string.IsNullOrEmpty(tenant) ? DefaultTenant : tenant
+        );
+    }
+}

--- a/src/Beckett/Messages/MessageConstants.cs
+++ b/src/Beckett/Messages/MessageConstants.cs
@@ -6,5 +6,6 @@ public static class MessageConstants
     {
         public const string CausationId = "$causation_id";
         public const string CorrelationId = "$correlation_id";
+        public const string Tenant = "$tenant";
     }
 }

--- a/src/Beckett/OpenTelemetry/IInstrumentation.cs
+++ b/src/Beckett/OpenTelemetry/IInstrumentation.cs
@@ -6,10 +6,7 @@ namespace Beckett.OpenTelemetry;
 public interface IInstrumentation
 {
     Activity? StartAppendToStreamActivity(string streamName, Dictionary<string, string> metadata);
-    Activity? StartSessionAppendToStreamActivity(string streamName, Dictionary<string, string> metadata);
     Activity? StartHandleMessageActivity(Subscription subscription, IMessageContext messageContext);
     Activity? StartReadStreamActivity(string streamName);
-    Activity? StartReadStreamBatchActivity();
     Activity? StartScheduleMessageActivity(string streamName, Dictionary<string, string> metadata);
-    Activity? StartSessionSaveChangesActivity();
 }

--- a/src/Beckett/OpenTelemetry/NullInstrumentation.cs
+++ b/src/Beckett/OpenTelemetry/NullInstrumentation.cs
@@ -7,15 +7,9 @@ public class NullInstrumentation : IInstrumentation
 {
     public Activity? StartAppendToStreamActivity(string streamName, Dictionary<string, string> metadata) => null;
 
-    public Activity? StartSessionAppendToStreamActivity(string streamName, Dictionary<string, string> metadata) => null;
-
     public Activity? StartHandleMessageActivity(Subscription subscription, IMessageContext messageContext) => null;
 
     public Activity? StartReadStreamActivity(string streamName) => null;
 
-    public Activity? StartReadStreamBatchActivity() => null;
-
     public Activity? StartScheduleMessageActivity(string streamName, Dictionary<string, string> metadata) => null;
-
-    public Activity? StartSessionSaveChangesActivity() => null;
 }

--- a/src/Beckett/OpenTelemetry/TelemetryConstants.cs
+++ b/src/Beckett/OpenTelemetry/TelemetryConstants.cs
@@ -45,6 +45,7 @@ public static class TelemetryConstants
         public const string StreamName = "message.stream_name";
         public const string GlobalPosition = "message.global_position";
         public const string StreamPosition = "message.stream_position";
+        public const string Tenant = "message.tenant";
         public const string Type = "message.type";
     }
 }


### PR DESCRIPTION
- add support for `$tenant` which is carried forward via metadata across messages and subscriptions like `$correlation_id` and `$causation_id` is today
- add ability to set the current tenant manually (i.e. for a request scope) using `BeckettContext.SetTenant(...)`
- add ability to set the current correlation ID manually (i.e. for a request scope) using `BeckettContext.SetCorrelationId(...)`
- update metadata propagation handling so that it works without OTEL configured
- add index to support querying via tenant