### PR TITLE
Convert structs to records and classes where appropriate

### DIFF
--- a/src/Beckett.Testing/FakeCommandExecutor.cs
+++ b/src/Beckett.Testing/FakeCommandExecutor.cs
@@ -32,7 +32,7 @@ public class FakeCommandExecutor : ICommandExecutor
         ReceivedStreamName = streamName;
         ReceivedCommand = command;
 
-        var result = (CommandResult)(_result ?? new CommandResult());
+        var result = (CommandResult)(_result ?? new CommandResult(1));
 
         return Task.FromResult(result);
     }
@@ -52,7 +52,7 @@ public class FakeCommandExecutor : ICommandExecutor
         ReceivedStreamName = streamName;
         ReceivedCommand = command;
 
-        var result = (CommandResult)(_result ?? new CommandResult());
+        var result = (CommandResult)(_result ?? new CommandResult(1));
 
         return Task.FromResult(result);
     }
@@ -72,7 +72,7 @@ public class FakeCommandExecutor : ICommandExecutor
         ReceivedStreamName = streamName;
         ReceivedCommand = command;
 
-        var result = (CommandResult<TResult>)(_result ?? new CommandResult<TResult>());
+        var result = (CommandResult<TResult>)(_result ?? new CommandResult<TResult>(1, default!));
 
         return Task.FromResult(result);
     }
@@ -92,7 +92,7 @@ public class FakeCommandExecutor : ICommandExecutor
         ReceivedStreamName = streamName;
         ReceivedCommand = command;
 
-        var result = (CommandResult<TResult>)(_result ?? new CommandResult<TResult>());
+        var result = (CommandResult<TResult>)(_result ?? new CommandResult<TResult>(1, default!));
 
         return Task.FromResult(result);
     }
@@ -114,7 +114,7 @@ public class FakeCommandExecutor : ICommandExecutor
         ReceivedCommand = command;
         ReceivedOptions = options;
 
-        var result = (CommandResult)(_result ?? new CommandResult());
+        var result = (CommandResult)(_result ?? new CommandResult(1));
 
         return Task.FromResult(result);
     }
@@ -136,7 +136,7 @@ public class FakeCommandExecutor : ICommandExecutor
         ReceivedCommand = command;
         ReceivedOptions = options;
 
-        var result = (CommandResult)(_result ?? new CommandResult());
+        var result = (CommandResult)(_result ?? new CommandResult(1));
 
         return Task.FromResult(result);
     }
@@ -158,7 +158,7 @@ public class FakeCommandExecutor : ICommandExecutor
         ReceivedCommand = command;
         ReceivedOptions = options;
 
-        var result = (CommandResult<TResult>)(_result ?? new CommandResult<TResult>());
+        var result = (CommandResult<TResult>)(_result ?? new CommandResult<TResult>(1, default!));
 
         return Task.FromResult(result);
     }
@@ -180,7 +180,7 @@ public class FakeCommandExecutor : ICommandExecutor
         ReceivedCommand = command;
         ReceivedOptions = options;
 
-        var result = (CommandResult<TResult>)(_result ?? new CommandResult<TResult>());
+        var result = (CommandResult<TResult>)(_result ?? new CommandResult<TResult>(1, default!));
 
         return Task.FromResult(result);
     }

--- a/src/Beckett/Commands/CommandResult.cs
+++ b/src/Beckett/Commands/CommandResult.cs
@@ -1,5 +1,5 @@
 namespace Beckett.Commands;
 
-public readonly record struct CommandResult<TResult>(long StreamVersion, TResult Result);
+public record CommandResult<TResult>(long StreamVersion, TResult Result);
 
-public readonly record struct CommandResult(long StreamVersion);
+public record CommandResult(long StreamVersion);

--- a/src/Beckett/IAppendResult.cs
+++ b/src/Beckett/IAppendResult.cs
@@ -8,7 +8,4 @@ public interface IAppendResult
     long StreamVersion { get; }
 }
 
-public readonly struct AppendResult(long streamVersion) : IAppendResult
-{
-    public long StreamVersion { get; } = streamVersion;
-}
+public readonly record struct AppendResult(long StreamVersion) : IAppendResult;

--- a/src/Beckett/IMessageBatch.cs
+++ b/src/Beckett/IMessageBatch.cs
@@ -9,7 +9,7 @@ public interface IMessageBatch
     IReadOnlyList<object> Messages { get; }
 }
 
-public readonly struct MessageBatch(string streamName, IReadOnlyList<StreamMessage> streamMessages) : IMessageBatch
+public class MessageBatch(string streamName, IReadOnlyList<StreamMessage> streamMessages) : IMessageBatch
 {
     public string StreamName { get; } = streamName;
 

--- a/src/Beckett/IMessageStream.cs
+++ b/src/Beckett/IMessageStream.cs
@@ -109,7 +109,7 @@ public static class MessageStreamExtensions
     ) => messageStream.Append(messages.Select(x => new Message(x)), cancellationToken);
 }
 
-public readonly struct MessageStream(
+public class MessageStream(
     string streamName,
     long streamVersion,
     IReadOnlyList<StreamMessage> streamMessages,

--- a/src/Beckett/Message.cs
+++ b/src/Beckett/Message.cs
@@ -6,7 +6,7 @@ namespace Beckett;
 /// <summary>
 /// Message envelope used to write messages in Beckett
 /// </summary>
-public readonly record struct Message
+public class Message
 {
     private static readonly JsonDocument EmptyJsonDocument = JsonDocument.Parse("{}");
     private static readonly Type MetadataDictionaryType = typeof(Dictionary<string, string>);

--- a/src/Beckett/MessageStorage/AppendToStreamResult.cs
+++ b/src/Beckett/MessageStorage/AppendToStreamResult.cs
@@ -1,6 +1,3 @@
 namespace Beckett.MessageStorage;
 
-public readonly struct AppendToStreamResult(long streamVersion)
-{
-    public long StreamVersion { get; } = streamVersion;
-}
+public readonly record struct AppendToStreamResult(long StreamVersion);

--- a/src/Beckett/MessageStorage/ReadGlobalStreamResult.cs
+++ b/src/Beckett/MessageStorage/ReadGlobalStreamResult.cs
@@ -1,6 +1,3 @@
 namespace Beckett.MessageStorage;
 
-public readonly struct ReadGlobalStreamResult(IReadOnlyList<GlobalStreamItem> items)
-{
-    public IReadOnlyList<GlobalStreamItem> Items { get; } = items;
-}
+public record ReadGlobalStreamResult(IReadOnlyList<GlobalStreamItem> Items);

--- a/src/Beckett/MessageStorage/ReadStreamResult.cs
+++ b/src/Beckett/MessageStorage/ReadStreamResult.cs
@@ -1,12 +1,3 @@
 namespace Beckett.MessageStorage;
 
-public readonly struct ReadStreamResult(
-    string streamName,
-    long streamVersion,
-    IReadOnlyList<StreamMessage> streamMessages
-)
-{
-    public string StreamName { get; } = streamName;
-    public long StreamVersion { get; } = streamVersion;
-    public IReadOnlyList<StreamMessage> Messages { get; } = streamMessages;
-}
+public record ReadStreamResult(string StreamName, long StreamVersion, IReadOnlyList<StreamMessage> Messages);

--- a/src/Beckett/Messages/MessageContext.cs
+++ b/src/Beckett/Messages/MessageContext.cs
@@ -2,7 +2,7 @@ using System.Text.Json;
 
 namespace Beckett.Messages;
 
-public readonly record struct MessageContext(
+public record MessageContext(
     string Id,
     string StreamName,
     long StreamPosition,

--- a/src/Beckett/Scheduling/ScheduledMessageContext.cs
+++ b/src/Beckett/Scheduling/ScheduledMessageContext.cs
@@ -1,10 +1,3 @@
 namespace Beckett.Scheduling;
 
-public readonly struct ScheduledMessageContext(
-    string streamName,
-    Message message
-)
-{
-    public string StreamName { get; } = streamName;
-    public Message Message { get; } = message;
-}
+public record ScheduledMessageContext(string StreamName, Message Message);

--- a/src/Beckett/StreamMessage.cs
+++ b/src/Beckett/StreamMessage.cs
@@ -3,7 +3,7 @@ using Beckett.Messages;
 
 namespace Beckett;
 
-public readonly record struct StreamMessage(
+public record StreamMessage(
     string Id,
     string StreamName,
     long StreamPosition,


### PR DESCRIPTION
There are a number of types that were defined as structs that should be classes, mostly because of the size of data they can potentially hold (i.e. large message payloads) - the official recommendation [here](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/choosing-between-class-and-struct) is to only use structs if the size of the data will be under 16KB.  