### PR TITLE
Read model source generator

### DIFF
--- a/Beckett.sln
+++ b/Beckett.sln
@@ -20,6 +20,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "samples\TaskHub\Te
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Beckett.Testing", "src\Beckett.Testing\Beckett.Testing.csproj", "{238A0F1F-0B14-4F53-92C1-A32488A8A96B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Beckett.SourceGenerators", "src\Beckett.SourceGenerators\Beckett.SourceGenerators.csproj", "{F75D8D08-1665-4C89-9BF3-775DB452C084}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -58,6 +60,10 @@ Global
 		{238A0F1F-0B14-4F53-92C1-A32488A8A96B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{238A0F1F-0B14-4F53-92C1-A32488A8A96B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{238A0F1F-0B14-4F53-92C1-A32488A8A96B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F75D8D08-1665-4C89-9BF3-775DB452C084}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F75D8D08-1665-4C89-9BF3-775DB452C084}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F75D8D08-1665-4C89-9BF3-775DB452C084}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F75D8D08-1665-4C89-9BF3-775DB452C084}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{EF59B95F-62EA-40AC-9F27-121138C1D031} = {A75ADB60-FDB3-48B5-82AA-FE7032842EF5}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <PackageVersion>0.15.0</PackageVersion>
+    <PackageVersion>0.16.0</PackageVersion>
     <AssemblyVersion>$(PackageVersion)</AssemblyVersion>
     <Authors>Matt Burton</Authors>
     <Description>Messaging and event sourcing library</Description>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,31 +4,33 @@
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="coverlet.collector" Version="6.0.3"/>
-    <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0"/>
+    <PackageVersion Include="coverlet.collector" Version="6.0.3" />
+    <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.0"/>
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0"/>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
-    <PackageVersion Include="Npgsql" Version="9.0.2"/>
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="Npgsql" Version="9.0.2" />
     <PackageVersion Include="Npgsql.DependencyInjection" Version="9.0.2" />
-    <PackageVersion Include="Npgsql.OpenTelemetry" Version="9.0.2"/>
-    <PackageVersion Include="OpenTelemetry" Version="1.10.0"/>
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.10.0"/>
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0"/>
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0"/>
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.10.1"/>
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.10.0"/>
-    <PackageVersion Include="Polly" Version="8.5.0"/>
-    <PackageVersion Include="Serilog.AspNetCore" Version="9.0.0"/>
-    <PackageVersion Include="Serilog.Extensions.Hosting" Version="9.0.0"/>
-    <PackageVersion Include="Serilog.Formatting.Compact" Version="3.0.0"/>
-    <PackageVersion Include="Serilog.Settings.Configuration" Version="9.0.0"/>
-    <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0"/>
-    <PackageVersion Include="System.Text.Encodings.Web" Version="9.0.0"/>
-    <PackageVersion Include="UUIDNext" Version="4.0.0"/>
-    <PackageVersion Include="xunit" Version="2.9.2"/>
-    <PackageVersion Include="xunit.assert" Version="2.9.2"/>
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0"/>
+    <PackageVersion Include="Npgsql.OpenTelemetry" Version="9.0.2" />
+    <PackageVersion Include="OpenTelemetry" Version="1.10.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.10.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.10.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.10.0" />
+    <PackageVersion Include="Polly" Version="8.5.0" />
+    <PackageVersion Include="Serilog.AspNetCore" Version="9.0.0" />
+    <PackageVersion Include="Serilog.Extensions.Hosting" Version="9.0.0" />
+    <PackageVersion Include="Serilog.Formatting.Compact" Version="3.0.0" />
+    <PackageVersion Include="Serilog.Settings.Configuration" Version="9.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageVersion Include="System.Text.Encodings.Web" Version="9.0.0" />
+    <PackageVersion Include="UUIDNext" Version="4.0.0" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="xunit.assert" Version="2.9.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
   </ItemGroup>
 </Project>

--- a/samples/TaskHub/TaskHub/TaskHub.csproj
+++ b/samples/TaskHub/TaskHub/TaskHub.csproj
@@ -19,4 +19,10 @@
     <PackageReference Include="Npgsql.DependencyInjection"/>
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Beckett.SourceGenerators\Beckett.SourceGenerators.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false"/>
+  </ItemGroup>
+
 </Project>

--- a/samples/TaskHub/TaskHub/TaskList/AddTask/AddTaskCommand.cs
+++ b/samples/TaskHub/TaskHub/TaskList/AddTask/AddTaskCommand.cs
@@ -2,7 +2,7 @@ using TaskHub.TaskList.Events;
 
 namespace TaskHub.TaskList.AddTask;
 
-public record AddTaskCommand(Guid TaskListId, string Task) : ICommand<AddTaskCommand.State>
+public partial record AddTaskCommand(Guid TaskListId, string Task) : ICommand<AddTaskCommand.State>
 {
     public IEnumerable<object> Execute(State state)
     {
@@ -14,21 +14,13 @@ public record AddTaskCommand(Guid TaskListId, string Task) : ICommand<AddTaskCom
         yield return new TaskAdded(TaskListId, Task);
     }
 
-    public class State : IApply
+    [ReadModel]
+    public partial class State
     {
         public HashSet<string> Items { get; } = [];
 
-        public void Apply(object message)
-        {
-            switch (message)
-            {
-                case TaskAdded e:
-                    Apply(e);
-                    break;
-            }
-        }
-
         private void Apply(TaskAdded e) => Items.Add(e.Task);
+
     }
 }
 

--- a/samples/TaskHub/TaskHub/TaskList/CompleteTask/CompleteTaskCommand.cs
+++ b/samples/TaskHub/TaskHub/TaskList/CompleteTask/CompleteTaskCommand.cs
@@ -2,7 +2,7 @@ using TaskHub.TaskList.Events;
 
 namespace TaskHub.TaskList.CompleteTask;
 
-public record CompleteTaskCommand(Guid TaskListId, string Task) : ICommand<CompleteTaskCommand.State>
+public partial record CompleteTaskCommand(Guid TaskListId, string Task) : ICommand<CompleteTaskCommand.State>
 {
     public IEnumerable<object> Execute(State state)
     {
@@ -14,16 +14,14 @@ public record CompleteTaskCommand(Guid TaskListId, string Task) : ICommand<Compl
         yield return new TaskCompleted(TaskListId, Task);
     }
 
-    public class State : IApply
+    [ReadModel]
+    public partial class State
     {
         public HashSet<string> CompletedItems { get; } = [];
 
-        public void Apply(object message)
+        private void Apply(TaskCompleted e)
         {
-            if (message is TaskCompleted e)
-            {
-                CompletedItems.Add(e.Task);
-            }
+            CompletedItems.Add(e.Task);
         }
     }
 }

--- a/samples/TaskHub/TaskHub/TaskList/GetList/GetListReadModel.cs
+++ b/samples/TaskHub/TaskHub/TaskList/GetList/GetListReadModel.cs
@@ -2,27 +2,12 @@ using TaskHub.TaskList.Events;
 
 namespace TaskHub.TaskList.GetList;
 
-public class GetListReadModel : IApply
+[ReadModel]
+public partial class GetListReadModel
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = null!;
     public List<TaskItem> Tasks { get; init; } = [];
-
-    public void Apply(object message)
-    {
-        switch (message)
-        {
-            case TaskListAdded e:
-                Apply(e);
-                break;
-            case TaskAdded e:
-                Apply(e);
-                break;
-            case TaskCompleted e:
-                Apply(e);
-                break;
-        }
-    }
 
     private void Apply(TaskListAdded e)
     {

--- a/samples/TaskHub/TaskHub/TaskList/GetLists/GetListsReadModel.cs
+++ b/samples/TaskHub/TaskHub/TaskList/GetLists/GetListsReadModel.cs
@@ -2,23 +2,11 @@ using TaskHub.TaskList.Events;
 
 namespace TaskHub.TaskList.GetLists;
 
-public class GetListsReadModel : IApply
+[ReadModel]
+public partial class GetListsReadModel
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = null!;
-
-    public void Apply(object message)
-    {
-        switch (message)
-        {
-            case TaskListAdded m:
-                Apply(m);
-                break;
-            case TaskListNameChanged m:
-                Apply(m);
-                break;
-        }
-    }
 
     private void Apply(TaskListAdded message)
     {

--- a/src/Beckett.SourceGenerators/Beckett.SourceGenerators.csproj
+++ b/src/Beckett.SourceGenerators/Beckett.SourceGenerators.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <IsRoslynComponent>true</IsRoslynComponent>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all"/>
+  </ItemGroup>
+
+</Project>

--- a/src/Beckett.SourceGenerators/ReadModelGenerator.cs
+++ b/src/Beckett.SourceGenerators/ReadModelGenerator.cs
@@ -1,0 +1,180 @@
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Beckett.SourceGenerators;
+
+[Generator]
+public sealed class ReadModelGenerator : IIncrementalGenerator
+{
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        context.RegisterPostInitializationOutput(
+            ctx => ctx.AddSource(
+                "ReadModelAttribute.g.cs",
+                SourceText.From(ReadModelTemplates.Attribute, Encoding.UTF8)
+            )
+        );
+
+        var readModels = context.SyntaxProvider.ForAttributeWithMetadataName(
+                "Beckett.ReadModelAttribute",
+                predicate: static (node, _) => IsSyntaxTargetForGeneration(node),
+                transform: static (context, _) => GetTargetForGeneration(context)
+            )
+            .Where(static m => m is not null);
+
+        context.RegisterSourceOutput(readModels, (sourceContext, data) => Execute(data, sourceContext));
+    }
+
+    private static void Execute(ReadModel? readModel, SourceProductionContext context)
+    {
+        if (readModel is not { } value)
+        {
+            return;
+        }
+
+        var result = ReadModelTemplates.ReadModel(value);
+        var fileName = ReadModelTemplates.FileName(value);
+
+        context.AddSource(fileName, SourceText.From(result, Encoding.UTF8));
+    }
+
+    private static ReadModel? GetTargetForGeneration(GeneratorAttributeSyntaxContext context)
+    {
+        return context.TargetSymbol is not INamedTypeSymbol symbol ? null : new ReadModel(symbol);
+    }
+
+    private static bool IsSyntaxTargetForGeneration(SyntaxNode node) =>
+        node is ClassDeclarationSyntax { AttributeLists.Count: > 0 };
+}
+
+public readonly record struct ReadModel
+{
+    public ReadModel(INamedTypeSymbol symbol)
+    {
+        ContainingNamespace = symbol.ContainingNamespace.ToString();
+        ContainingTypeName = symbol.ContainingType?.Name;
+        ContainingTypeAccessModifier = AccessibilityModifier(symbol.ContainingType?.DeclaredAccessibility);
+        ContainingTypeIsRecord = symbol.ContainingType?.IsRecord ?? false;
+        Name = symbol.Name;
+        AccessModifier = AccessibilityModifier(symbol.DeclaredAccessibility);
+        MessageTypes = symbol.GetMembers("Apply")
+            .OfType<IMethodSymbol>()
+            .Where(x => x.ReturnsVoid)
+            .Where(x => x.Parameters.Length == 1)
+            .Select(BuildMessageTypeFullName)
+            .ToArray();
+    }
+
+    public readonly string ContainingNamespace;
+    public readonly string? ContainingTypeName;
+    public readonly string? ContainingTypeAccessModifier;
+    public readonly bool ContainingTypeIsRecord;
+    public readonly string Name;
+    public readonly string? AccessModifier;
+    public readonly string[] MessageTypes;
+
+    private static string BuildMessageTypeFullName(IMethodSymbol method)
+    {
+        var message = method.Parameters[0];
+
+        var builder = new StringBuilder();
+
+        builder.Append(message.Type.ContainingNamespace);
+        builder.Append('.');
+
+        if (message.Type.ContainingType != null)
+        {
+            builder.Append(message.Type.ContainingType.Name);
+            builder.Append('.');
+        }
+
+        builder.Append(message.Type.Name);
+
+        return builder.ToString();
+    }
+
+    private static string? AccessibilityModifier(Accessibility? accessibility)
+    {
+        return accessibility switch
+        {
+            Accessibility.Private => "private",
+            Accessibility.Protected => "protected",
+            Accessibility.Internal => "internal",
+            Accessibility.Public => "public",
+            _ => null
+        };
+    }
+}
+
+public static class ReadModelTemplates
+{
+    public const string Attribute = @"
+namespace Beckett
+{
+    [System.AttributeUsage(System.AttributeTargets.Class)]
+    public class ReadModelAttribute : System.Attribute
+    {
+    }
+}
+    ";
+
+    public static string FileName(ReadModel readModel)
+    {
+        return readModel.ContainingTypeName != null
+            ? $"{readModel.ContainingNamespace}.{readModel.ContainingTypeName}.{readModel.Name}.g.cs"
+            : $"{readModel.ContainingNamespace}.{readModel.Name}.g.cs";
+    }
+
+    public static string ReadModel(ReadModel readModel)
+    {
+        return readModel.ContainingTypeName != null
+            ? NestedReadModel(readModel)
+            : $@"
+using Beckett;
+
+namespace {readModel.ContainingNamespace}
+{{
+    {readModel.AccessModifier} partial class {readModel.Name} : IApply
+    {{
+        public void Apply(object message)
+        {{
+            switch (message)
+            {{
+                {string.Join("\n", readModel.MessageTypes.Select(MessageTypeSwitchCase))}
+            }}
+        }}
+    }}
+}}
+    ";
+    }
+
+    public static string NestedReadModel(ReadModel readModel) => $@"
+using Beckett;
+
+namespace {readModel.ContainingNamespace}
+{{
+    {readModel.ContainingTypeAccessModifier} partial {(readModel.ContainingTypeIsRecord ? "record" : "class")} {readModel.ContainingTypeName}
+    {{
+        {readModel.AccessModifier} partial class {readModel.Name} : IApply
+        {{
+            public void Apply(object message)
+            {{
+                switch (message)
+                {{
+                    {string.Join("\n", readModel.MessageTypes.Select(MessageTypeSwitchCase))}
+                }}
+            }}
+        }}
+    }}
+}}
+    ";
+
+    private static string MessageTypeSwitchCase(string messageType) => $@"
+                case {messageType} m:
+                    Apply(m);
+                    break;
+";
+}

--- a/src/Beckett.SourceGenerators/packages.lock.json
+++ b/src/Beckett.SourceGenerators/packages.lock.json
@@ -1,0 +1,121 @@
+{
+  "version": 2,
+  "dependencies": {
+    ".NETStandard,Version=v2.0": {
+      "Microsoft.CodeAnalysis.Analyzers": {
+        "type": "Direct",
+        "requested": "[3.11.0, )",
+        "resolved": "3.11.0",
+        "contentHash": "v/EW3UE8/lbEYHoC2Qq7AR/DnmvpgdtAMndfQNmpuIMx/Mto8L5JnuCfdBYtgvalQOtfNCnxFejxuRrryvUTsg=="
+      },
+      "Microsoft.CodeAnalysis.CSharp": {
+        "type": "Direct",
+        "requested": "[4.12.0, )",
+        "resolved": "4.12.0",
+        "contentHash": "30vVQ1MizeC22iEdEvI2w0eTIYG43/L20yBzuQH01xKzJgHAoWehzI2F8u07o4mXh4DGMOjQF7aEm0zzvsG3Mg==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.3.4",
+          "Microsoft.CodeAnalysis.Common": "[4.12.0]",
+          "System.Buffers": "4.5.1",
+          "System.Collections.Immutable": "8.0.0",
+          "System.Memory": "4.5.5",
+          "System.Numerics.Vectors": "4.5.0",
+          "System.Reflection.Metadata": "8.0.0",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.Encoding.CodePages": "7.0.0",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
+      "NETStandard.Library": {
+        "type": "Direct",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Common": {
+        "type": "Transitive",
+        "resolved": "4.12.0",
+        "contentHash": "c1kNYihL2gdcuU1dqm8R8YeA4YkB43TpU3pa2r66Uooh6AAhRtENzj9A4Kj0a+H8JDDyuTjNZql9XlVUzV+UjA==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.3.4",
+          "System.Buffers": "4.5.1",
+          "System.Collections.Immutable": "8.0.0",
+          "System.Memory": "4.5.5",
+          "System.Numerics.Vectors": "4.5.0",
+          "System.Reflection.Metadata": "8.0.0",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.Encoding.CodePages": "7.0.0",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
+      },
+      "System.Buffers": {
+        "type": "Transitive",
+        "resolved": "4.5.1",
+        "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
+      },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg==",
+        "dependencies": {
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Memory": {
+        "type": "Transitive",
+        "resolved": "4.5.5",
+        "contentHash": "XIWiDvKPXaTveaB7HVganDlOCRoj03l+jrwNvcge/t8vhGYKvqV+dMv6G4SAX2NoNmN0wZfVPTAlFwZcZvVOUw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Numerics.Vectors": "4.4.0",
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+        }
+      },
+      "System.Numerics.Vectors": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "QQTlPTl06J/iiDbJCiepZ4H//BVraReU4O4EoRw1U02H5TLUIT7xn3GnDp9AXPSlJUDyFs4uWjWafNX6WrAojQ=="
+      },
+      "System.Reflection.Metadata": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "ptvgrFh7PvWI8bcVqG5rsA/weWM09EnthFHR5SCnS6IN+P4mj6rE1lBDC4U8HL9/57htKAqy4KQ3bBj84cfYyQ==",
+        "dependencies": {
+          "System.Collections.Immutable": "8.0.0",
+          "System.Memory": "4.5.5"
+        }
+      },
+      "System.Runtime.CompilerServices.Unsafe": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+      },
+      "System.Text.Encoding.CodePages": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "LSyCblMpvOe0N3E+8e0skHcrIhgV2huaNcjUUEa8hRtgEAm36aGkRoC8Jxlb6Ra6GSfF29ftduPNywin8XolzQ==",
+        "dependencies": {
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+        }
+      }
+    }
+  }
+}

--- a/src/Beckett/Beckett.csproj
+++ b/src/Beckett/Beckett.csproj
@@ -33,4 +33,11 @@
     </AssemblyAttribute>
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="$(MSBuildProjectDirectory)\..\Beckett.SourceGenerators\bin\$(Configuration)\netstandard2.0\Beckett.SourceGenerators.dll"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs"
+          Visible="false"/>
+  </ItemGroup>
+
 </Project>

--- a/src/Beckett/packages.lock.json
+++ b/src/Beckett/packages.lock.json
@@ -188,6 +188,9 @@
         "resolved": "9.0.0",
         "contentHash": "ddppcFpnbohLWdYKr/ZeLZHmmI+DXFgZ3Snq+/E7SwcdW4UnvxmaugkwGywvGVWkHPGCSZjCP+MLzu23AL5SDw=="
       },
+      "beckett.sourcegenerators": {
+        "type": "Project"
+      },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[9.0.0, )",
@@ -373,6 +376,9 @@
         "type": "Transitive",
         "resolved": "9.0.0",
         "contentHash": "ddppcFpnbohLWdYKr/ZeLZHmmI+DXFgZ3Snq+/E7SwcdW4UnvxmaugkwGywvGVWkHPGCSZjCP+MLzu23AL5SDw=="
+      },
+      "beckett.sourcegenerators": {
+        "type": "Project"
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "CentralTransitive",


### PR DESCRIPTION
Source generator to automate writing the `public void Apply(object message)` method when implementing `IApply`. Example:

```csharp
public partial record AddTaskCommand(Guid TaskListId, string Task) : ICommand<AddTaskCommand.State>
{
    public IEnumerable<object> Execute(State state)
    {
        if (state.Items.Contains(Task))
        {
            throw new TaskAlreadyAddedException();
        }

        yield return new TaskAdded(TaskListId, Task);
    }

    [ReadModel]
    public partial class State
    {
        public HashSet<string> Items { get; } = [];

        private void Apply(TaskAdded e) => Items.Add(e.Task);

    }
}
```

I'm using this example to demonstrate nested types like we typically do in commands - both the read model class itself and the outer class / record needs to be marked as `partial` in order for the source generator to create the necessary backing class.