### PR TITLE
Dashboard - rename handlers to endpoints

### DIFF
--- a/src/Beckett.Dashboard/Administration/RefreshTenants/RefreshTenantsEndpoint.cs
+++ b/src/Beckett.Dashboard/Administration/RefreshTenants/RefreshTenantsEndpoint.cs
@@ -1,8 +1,8 @@
 namespace Beckett.Dashboard.Administration.RefreshTenants;
 
-public static class RefreshTenantsHandler
+public static class RefreshTenantsEndpoint
 {
-    public static async Task<IResult> Post(
+    public static async Task<IResult> Handle(
         HttpContext context,
         IDashboard dashboard,
         CancellationToken cancellationToken

--- a/src/Beckett.Dashboard/Administration/Routes.cs
+++ b/src/Beckett.Dashboard/Administration/Routes.cs
@@ -8,6 +8,6 @@ public class Routes : IConfigureRoutes
     {
         var routes = builder.MapGroup("/administration");
 
-        routes.MapPost("/refresh-tenants", RefreshTenantsHandler.Post);
+        routes.MapPost("/refresh-tenants", RefreshTenantsEndpoint.Handle);
     }
 }

--- a/src/Beckett.Dashboard/MessageStore/GetCategories/GetCategoriesEndpoint.cs
+++ b/src/Beckett.Dashboard/MessageStore/GetCategories/GetCategoriesEndpoint.cs
@@ -1,9 +1,11 @@
-namespace Beckett.Dashboard.MessageStore.GetCorrelatedBy;
+using Beckett.Dashboard.MessageStore.Shared.Components;
 
-public static class GetCorrelatedByHandler
+namespace Beckett.Dashboard.MessageStore.GetCategories;
+
+public static class GetCategoriesEndpoint
 {
-    public static async Task<IResult> Get(
-        string correlationId,
+    public static async Task<IResult> Handle(
+        HttpContext context,
         string? query,
         int? page,
         int? pageSize,
@@ -11,22 +13,22 @@ public static class GetCorrelatedByHandler
         CancellationToken cancellationToken
     )
     {
+        var tenant = TenantFilter.GetCurrentTenant(context);
         var pageParameter = page.ToPageParameter();
         var pageSizeParameter = pageSize.ToPageSizeParameter();
 
-        var result = await dashboard.MessageStore.GetCorrelatedMessages(
-            correlationId,
+        var result = await dashboard.MessageStore.GetCategories(
+            tenant,
             query,
             pageParameter,
             pageSizeParameter,
             cancellationToken
         );
 
-        return Results.Extensions.Render<CorrelatedBy>(
-            new CorrelatedBy.ViewModel(
-                correlationId,
+        return Results.Extensions.Render<Categories>(
+            new Categories.ViewModel(
+                result.Categories,
                 query,
-                result.Messages,
                 pageParameter,
                 pageSizeParameter,
                 result.TotalResults

--- a/src/Beckett.Dashboard/MessageStore/GetCorrelatedBy/GetCorrelatedByEndpoint.cs
+++ b/src/Beckett.Dashboard/MessageStore/GetCorrelatedBy/GetCorrelatedByEndpoint.cs
@@ -1,8 +1,9 @@
-namespace Beckett.Dashboard.Subscriptions.Checkpoints.GetRetries;
+namespace Beckett.Dashboard.MessageStore.GetCorrelatedBy;
 
-public static class GetRetriesHandler
+public static class GetCorrelatedByEndpoint
 {
-    public static async Task<IResult> Get(
+    public static async Task<IResult> Handle(
+        string correlationId,
         string? query,
         int? page,
         int? pageSize,
@@ -13,17 +14,19 @@ public static class GetRetriesHandler
         var pageParameter = page.ToPageParameter();
         var pageSizeParameter = pageSize.ToPageSizeParameter();
 
-        var result = await dashboard.Subscriptions.GetRetries(
+        var result = await dashboard.MessageStore.GetCorrelatedMessages(
+            correlationId,
             query,
             pageParameter,
             pageSizeParameter,
             cancellationToken
         );
 
-        return Results.Extensions.Render<Retries>(
-            new Retries.ViewModel(
-                result.Retries,
+        return Results.Extensions.Render<CorrelatedBy>(
+            new CorrelatedBy.ViewModel(
+                correlationId,
                 query,
+                result.Messages,
                 pageParameter,
                 pageSizeParameter,
                 result.TotalResults

--- a/src/Beckett.Dashboard/MessageStore/GetMessage/GetMessageByIdEndpoint.cs
+++ b/src/Beckett.Dashboard/MessageStore/GetMessage/GetMessageByIdEndpoint.cs
@@ -1,0 +1,15 @@
+namespace Beckett.Dashboard.MessageStore.GetMessage;
+
+public static class GetMessageByIdEndpoint
+{
+    public static async Task<IResult> Handle(
+        string id,
+        IDashboard dashboard,
+        CancellationToken cancellationToken
+    )
+    {
+        var result = await dashboard.MessageStore.GetMessage(id, cancellationToken);
+
+        return result is null ? Results.NotFound() : Results.Extensions.Render<Message>(new Message.ViewModel(result));
+    }
+}

--- a/src/Beckett.Dashboard/MessageStore/GetMessage/GetMessageByStreamPositionEndpoint.cs
+++ b/src/Beckett.Dashboard/MessageStore/GetMessage/GetMessageByStreamPositionEndpoint.cs
@@ -1,19 +1,8 @@
 namespace Beckett.Dashboard.MessageStore.GetMessage;
 
-public static class GetMessageHandler
+public static class GetMessageByStreamPositionEndpoint
 {
-    public static async Task<IResult> GetById(
-        string id,
-        IDashboard dashboard,
-        CancellationToken cancellationToken
-    )
-    {
-        var result = await dashboard.MessageStore.GetMessage(id, cancellationToken);
-
-        return result is null ? Results.NotFound() : Results.Extensions.Render<Message>(new Message.ViewModel(result));
-    }
-
-    public static async Task<IResult> GetByStreamPosition(
+    public static async Task<IResult> Handle(
         string streamName,
         long streamPosition,
         IDashboard dashboard,

--- a/src/Beckett.Dashboard/MessageStore/GetMessages/GetMessagesEndpoint.cs
+++ b/src/Beckett.Dashboard/MessageStore/GetMessages/GetMessagesEndpoint.cs
@@ -1,8 +1,8 @@
 namespace Beckett.Dashboard.MessageStore.GetMessages;
 
-public static class GetMessagesHandler
+public static class GetMessagesEndpoint
 {
-    public static async Task<IResult> Get(
+    public static async Task<IResult> Handle(
         string category,
         string streamName,
         string? query,

--- a/src/Beckett.Dashboard/MessageStore/GetStreams/GetStreamsEndpoint.cs
+++ b/src/Beckett.Dashboard/MessageStore/GetStreams/GetStreamsEndpoint.cs
@@ -2,9 +2,9 @@ using Beckett.Dashboard.MessageStore.Shared.Components;
 
 namespace Beckett.Dashboard.MessageStore.GetStreams;
 
-public static class GetStreamsHandler
+public static class GetStreamsEndpoint
 {
-    public static async Task<IResult> Get(
+    public static async Task<IResult> Handle(
         HttpContext context,
         string category,
         string? query,

--- a/src/Beckett.Dashboard/MessageStore/Routes.cs
+++ b/src/Beckett.Dashboard/MessageStore/Routes.cs
@@ -17,11 +17,11 @@ public class Routes : IConfigureRoutes
 
         var routes = builder.MapGroup("/message-store");
 
-        routes.MapGet("/", GetCategoriesHandler.Get);
-        routes.MapGet("/categories/{category}", GetStreamsHandler.Get);
-        routes.MapGet("/categories/{category}/{streamName}", GetMessagesHandler.Get);
-        routes.MapGet("/correlated-by/{correlationId}", GetCorrelatedByHandler.Get);
-        routes.MapGet("/messages/{id}", GetMessageHandler.GetById);
-        routes.MapGet("/streams/{streamName}/{streamPosition:long}", GetMessageHandler.GetByStreamPosition);
+        routes.MapGet("/", GetCategoriesEndpoint.Handle);
+        routes.MapGet("/categories/{category}", GetStreamsEndpoint.Handle);
+        routes.MapGet("/categories/{category}/{streamName}", GetMessagesEndpoint.Handle);
+        routes.MapGet("/correlated-by/{correlationId}", GetCorrelatedByEndpoint.Handle);
+        routes.MapGet("/messages/{id}", GetMessageByIdEndpoint.Handle);
+        routes.MapGet("/streams/{streamName}/{streamPosition:long}", GetMessageByStreamPositionEndpoint.Handle);
     }
 }

--- a/src/Beckett.Dashboard/Metrics/GetMetrics/GetMetricsEndpoint.cs
+++ b/src/Beckett.Dashboard/Metrics/GetMetrics/GetMetricsEndpoint.cs
@@ -1,8 +1,8 @@
 namespace Beckett.Dashboard.Metrics.GetMetrics;
 
-public static class GetMetricsHandler
+public static class GetMetricsEndpoint
 {
-    public static async Task<IResult> Get(IDashboard dashboard, CancellationToken cancellationToken)
+    public static async Task<IResult> Handle(IDashboard dashboard, CancellationToken cancellationToken)
     {
         var result = await dashboard.Metrics.GetSubscriptionMetrics(cancellationToken);
 

--- a/src/Beckett.Dashboard/Metrics/Routes.cs
+++ b/src/Beckett.Dashboard/Metrics/Routes.cs
@@ -4,5 +4,5 @@ namespace Beckett.Dashboard.Metrics;
 
 public class Routes : IConfigureRoutes
 {
-    public void Configure(IEndpointRouteBuilder builder) => builder.MapGet("/metrics", GetMetricsHandler.Get);
+    public void Configure(IEndpointRouteBuilder builder) => builder.MapGet("/metrics", GetMetricsEndpoint.Handle);
 }

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/BulkRetry/BulkRetryEndpoint.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/BulkRetry/BulkRetryEndpoint.cs
@@ -1,20 +1,20 @@
 using Beckett.Subscriptions.Retries;
 
-namespace Beckett.Dashboard.Subscriptions.Checkpoints.BulkSkip;
+namespace Beckett.Dashboard.Subscriptions.Checkpoints.BulkRetry;
 
-public static class BulkSkipHandler
+public static class BulkRetryEndpoint
 {
-    public static async Task<IResult> Post(
+    public static async Task<IResult> Handle(
         HttpContext context,
         [FromForm(Name = "id")] long[] ids,
         IRetryClient retryClient,
         CancellationToken cancellationToken
     )
     {
-        await retryClient.BulkSkip(ids, cancellationToken);
+        await retryClient.BulkRetry(ids, cancellationToken);
 
         context.Response.Headers.Append("HX-Refresh", new StringValues("true"));
-        context.Response.Headers.Append("HX-Trigger", new StringValues("bulk_skip_requested"));
+        context.Response.Headers.Append("HX-Trigger", new StringValues("bulk_retry_requested"));
 
         return Results.Ok();
     }

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/BulkSkip/BulkSkipEndpoint.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/BulkSkip/BulkSkipEndpoint.cs
@@ -1,20 +1,20 @@
 using Beckett.Subscriptions.Retries;
 
-namespace Beckett.Dashboard.Subscriptions.Checkpoints.BulkRetry;
+namespace Beckett.Dashboard.Subscriptions.Checkpoints.BulkSkip;
 
-public static class BulkRetryHandler
+public static class BulkSkipEndpoint
 {
-    public static async Task<IResult> Post(
+    public static async Task<IResult> Handle(
         HttpContext context,
         [FromForm(Name = "id")] long[] ids,
         IRetryClient retryClient,
         CancellationToken cancellationToken
     )
     {
-        await retryClient.BulkRetry(ids, cancellationToken);
+        await retryClient.BulkSkip(ids, cancellationToken);
 
         context.Response.Headers.Append("HX-Refresh", new StringValues("true"));
-        context.Response.Headers.Append("HX-Trigger", new StringValues("bulk_retry_requested"));
+        context.Response.Headers.Append("HX-Trigger", new StringValues("bulk_skip_requested"));
 
         return Results.Ok();
     }

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/GetCheckpoint/GetCheckpointEndpoint.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/GetCheckpoint/GetCheckpointEndpoint.cs
@@ -1,8 +1,8 @@
 namespace Beckett.Dashboard.Subscriptions.Checkpoints.GetCheckpoint;
 
-public static class GetCheckpointHandler
+public static class GetCheckpointEndpoint
 {
-    public static async Task<IResult> Get(long id, IDashboard dashboard, CancellationToken cancellationToken)
+    public static async Task<IResult> Handle(long id, IDashboard dashboard, CancellationToken cancellationToken)
     {
         var result = await dashboard.Subscriptions.GetCheckpoint(id, cancellationToken);
 

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/GetFailed/GetFailedEndpoint.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/GetFailed/GetFailedEndpoint.cs
@@ -1,8 +1,8 @@
 namespace Beckett.Dashboard.Subscriptions.Checkpoints.GetFailed;
 
-public static class GetFailedHandler
+public static class GetFailedEndpoint
 {
-    public static async Task<IResult> Get(
+    public static async Task<IResult> Handle(
         string? query,
         int? page,
         int? pageSize,

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/GetLagging/GetLaggingEndpoint.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/GetLagging/GetLaggingEndpoint.cs
@@ -1,8 +1,8 @@
 namespace Beckett.Dashboard.Subscriptions.Checkpoints.GetLagging;
 
-public static class GetLaggingHandler
+public static class GetLaggingEndpoint
 {
-    public static async Task<IResult> Get(
+    public static async Task<IResult> Handle(
         int? page,
         int? pageSize,
         IDashboard dashboard,

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/GetReservations/GetReservationsEndpoint.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/GetReservations/GetReservationsEndpoint.cs
@@ -1,11 +1,8 @@
-using Beckett.Dashboard.MessageStore.Shared.Components;
+namespace Beckett.Dashboard.Subscriptions.Checkpoints.GetReservations;
 
-namespace Beckett.Dashboard.MessageStore.GetCategories;
-
-public static class GetCategoriesHandler
+public static class GetReservationsEndpoint
 {
-    public static async Task<IResult> Get(
-        HttpContext context,
+    public static async Task<IResult> Handle(
         string? query,
         int? page,
         int? pageSize,
@@ -13,21 +10,19 @@ public static class GetCategoriesHandler
         CancellationToken cancellationToken
     )
     {
-        var tenant = TenantFilter.GetCurrentTenant(context);
         var pageParameter = page.ToPageParameter();
         var pageSizeParameter = pageSize.ToPageSizeParameter();
 
-        var result = await dashboard.MessageStore.GetCategories(
-            tenant,
+        var result = await dashboard.Subscriptions.GetReservations(
             query,
             pageParameter,
             pageSizeParameter,
             cancellationToken
         );
 
-        return Results.Extensions.Render<Categories>(
-            new Categories.ViewModel(
-                result.Categories,
+        return Results.Extensions.Render<Reservations>(
+            new Reservations.ViewModel(
+                result.Reservations,
                 query,
                 pageParameter,
                 pageSizeParameter,

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/GetRetries/GetRetriesEndpoint.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/GetRetries/GetRetriesEndpoint.cs
@@ -1,8 +1,8 @@
-namespace Beckett.Dashboard.Subscriptions.Checkpoints.GetReservations;
+namespace Beckett.Dashboard.Subscriptions.Checkpoints.GetRetries;
 
-public static class GetReservationsHandler
+public static class GetRetriesEndpoint
 {
-    public static async Task<IResult> Get(
+    public static async Task<IResult> Handle(
         string? query,
         int? page,
         int? pageSize,
@@ -13,16 +13,16 @@ public static class GetReservationsHandler
         var pageParameter = page.ToPageParameter();
         var pageSizeParameter = pageSize.ToPageSizeParameter();
 
-        var result = await dashboard.Subscriptions.GetReservations(
+        var result = await dashboard.Subscriptions.GetRetries(
             query,
             pageParameter,
             pageSizeParameter,
             cancellationToken
         );
 
-        return Results.Extensions.Render<Reservations>(
-            new Reservations.ViewModel(
-                result.Reservations,
+        return Results.Extensions.Render<Retries>(
+            new Retries.ViewModel(
+                result.Retries,
                 query,
                 pageParameter,
                 pageSizeParameter,

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/ReleaseReservation/ReleaseReservationEndpoint.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/ReleaseReservation/ReleaseReservationEndpoint.cs
@@ -1,8 +1,8 @@
 namespace Beckett.Dashboard.Subscriptions.Checkpoints.ReleaseReservation;
 
-public static class ReleaseReservationHandler
+public static class ReleaseReservationEndpoint
 {
-    public static async Task<IResult> Post(
+    public static async Task<IResult> Handle(
         HttpContext context,
         long id,
         IDashboard dashboard,

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/Retry/RetryEndpoint.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/Retry/RetryEndpoint.cs
@@ -2,9 +2,9 @@ using Beckett.Subscriptions.Retries;
 
 namespace Beckett.Dashboard.Subscriptions.Checkpoints.Retry;
 
-public static class RetryHandler
+public static class RetryEndpoint
 {
-    public static async Task<IResult> Post(
+    public static async Task<IResult> Handle(
         HttpContext context,
         long id,
         IRetryClient retryClient,

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/Routes.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/Routes.cs
@@ -17,15 +17,15 @@ public class Routes : IConfigureRoutes
     {
         var routes = builder.MapGroup("/subscriptions/checkpoints");
 
-        routes.MapGet("/{id:long}", GetCheckpointHandler.Get);
-        routes.MapPost("/{id:long}/release-reservation", ReleaseReservationHandler.Post).DisableAntiforgery();
-        routes.MapPost("/{id:long}/retry", RetryHandler.Post).DisableAntiforgery();
-        routes.MapPost("/{id:long}/skip", SkipHandler.Post).DisableAntiforgery();
-        routes.MapPost("/bulk-retry", BulkRetryHandler.Post).DisableAntiforgery();
-        routes.MapPost("/bulk-skip", BulkSkipHandler.Post).DisableAntiforgery();
-        routes.MapGet("/failed", GetFailedHandler.Get);
-        routes.MapGet("/lagging", GetLaggingHandler.Get);
-        routes.MapGet("/reservations", GetReservationsHandler.Get);
-        routes.MapGet("/retries", GetRetriesHandler.Get);
+        routes.MapGet("/{id:long}", GetCheckpointEndpoint.Handle);
+        routes.MapPost("/{id:long}/release-reservation", ReleaseReservationEndpoint.Handle).DisableAntiforgery();
+        routes.MapPost("/{id:long}/retry", RetryEndpoint.Handle).DisableAntiforgery();
+        routes.MapPost("/{id:long}/skip", SkipEndpoint.Handle).DisableAntiforgery();
+        routes.MapPost("/bulk-retry", BulkRetryEndpoint.Handle).DisableAntiforgery();
+        routes.MapPost("/bulk-skip", BulkSkipEndpoint.Handle).DisableAntiforgery();
+        routes.MapGet("/failed", GetFailedEndpoint.Handle);
+        routes.MapGet("/lagging", GetLaggingEndpoint.Handle);
+        routes.MapGet("/reservations", GetReservationsEndpoint.Handle);
+        routes.MapGet("/retries", GetRetriesEndpoint.Handle);
     }
 }

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/Skip/SkipEndpoint.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/Skip/SkipEndpoint.cs
@@ -2,9 +2,9 @@ using Beckett.Subscriptions.Retries;
 
 namespace Beckett.Dashboard.Subscriptions.Checkpoints.Skip;
 
-public static class SkipHandler
+public static class SkipEndpoint
 {
-    public static async Task<IResult> Post(
+    public static async Task<IResult> Handle(
         HttpContext context,
         long id,
         IRetryClient retryClient,

--- a/src/Beckett.Dashboard/Subscriptions/GetSubscription/GetSubscriptionEndpoint.cs
+++ b/src/Beckett.Dashboard/Subscriptions/GetSubscription/GetSubscriptionEndpoint.cs
@@ -1,8 +1,8 @@
 namespace Beckett.Dashboard.Subscriptions.GetSubscription;
 
-public static class GetSubscriptionHandler
+public static class GetSubscriptionEndpoint
 {
-    public static async Task<IResult> Get(
+    public static async Task<IResult> Handle(
         string groupName,
         string name,
         IDashboard dashboard,

--- a/src/Beckett.Dashboard/Subscriptions/GetSubscriptions/GetSubscriptionsEndpoint.cs
+++ b/src/Beckett.Dashboard/Subscriptions/GetSubscriptions/GetSubscriptionsEndpoint.cs
@@ -1,8 +1,8 @@
 namespace Beckett.Dashboard.Subscriptions.GetSubscriptions;
 
-public static class GetSubscriptionsHandler
+public static class GetSubscriptionsEndpoint
 {
-    public static async Task<IResult> Get(
+    public static async Task<IResult> Handle(
         string? query,
         int? page,
         int? pageSize,

--- a/src/Beckett.Dashboard/Subscriptions/Pause/PauseEndpoint.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Pause/PauseEndpoint.cs
@@ -1,10 +1,10 @@
 using Beckett.Database;
 
-namespace Beckett.Dashboard.Subscriptions.Resume;
+namespace Beckett.Dashboard.Subscriptions.Pause;
 
-public static class ResumeHandler
+public static class PauseEndpoint
 {
-    public static async Task<IResult> Post(
+    public static async Task<IResult> Handle(
         HttpContext context,
         string groupName,
         string name,
@@ -13,7 +13,7 @@ public static class ResumeHandler
         CancellationToken cancellationToken
     )
     {
-        await database.Execute(new Beckett.Subscriptions.Queries.ResumeSubscription(groupName, name, options), cancellationToken);
+        await database.Execute(new Beckett.Subscriptions.Queries.PauseSubscription(groupName, name, options), cancellationToken);
 
         context.Response.Headers.Append("HX-Refresh", new StringValues("true"));
 

--- a/src/Beckett.Dashboard/Subscriptions/Reset/ResetEndpoint.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Reset/ResetEndpoint.cs
@@ -1,8 +1,8 @@
 namespace Beckett.Dashboard.Subscriptions.Reset;
 
-public static class ResetHandler
+public static class ResetEndpoint
 {
-    public static async Task<IResult> Post(
+    public static async Task<IResult> Handle(
         HttpContext context,
         string groupName,
         string name,

--- a/src/Beckett.Dashboard/Subscriptions/Resume/ResumeEndpoint.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Resume/ResumeEndpoint.cs
@@ -1,10 +1,10 @@
 using Beckett.Database;
 
-namespace Beckett.Dashboard.Subscriptions.Pause;
+namespace Beckett.Dashboard.Subscriptions.Resume;
 
-public static class PauseHandler
+public static class ResumeEndpoint
 {
-    public static async Task<IResult> Post(
+    public static async Task<IResult> Handle(
         HttpContext context,
         string groupName,
         string name,
@@ -13,7 +13,7 @@ public static class PauseHandler
         CancellationToken cancellationToken
     )
     {
-        await database.Execute(new Beckett.Subscriptions.Queries.PauseSubscription(groupName, name, options), cancellationToken);
+        await database.Execute(new Beckett.Subscriptions.Queries.ResumeSubscription(groupName, name, options), cancellationToken);
 
         context.Response.Headers.Append("HX-Refresh", new StringValues("true"));
 

--- a/src/Beckett.Dashboard/Subscriptions/Routes.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Routes.cs
@@ -12,10 +12,10 @@ public class Routes : IConfigureRoutes
     {
         var routes = builder.MapGroup("/subscriptions");
 
-        routes.MapGet("/", GetSubscriptionsHandler.Get);
-        routes.MapGet("/{groupName}/{name}", GetSubscriptionHandler.Get);
-        routes.MapPost("/{groupName}/{name}/pause", PauseHandler.Post).DisableAntiforgery();
-        routes.MapPost("/{groupName}/{name}/reset", ResetHandler.Post).DisableAntiforgery();
-        routes.MapPost("/{groupName}/{name}/resume", ResumeHandler.Post).DisableAntiforgery();
+        routes.MapGet("/", GetSubscriptionsEndpoint.Handle);
+        routes.MapGet("/{groupName}/{name}", GetSubscriptionEndpoint.Handle);
+        routes.MapPost("/{groupName}/{name}/pause", PauseEndpoint.Handle).DisableAntiforgery();
+        routes.MapPost("/{groupName}/{name}/reset", ResetEndpoint.Handle).DisableAntiforgery();
+        routes.MapPost("/{groupName}/{name}/resume", ResumeEndpoint.Handle).DisableAntiforgery();
     }
 }


### PR DESCRIPTION
- use "endpoints" instead of "handlers" in the dashboard