### PR TITLE
Projection updates

### DIFF
--- a/src/Beckett.SourceGenerators/StateGenerator.cs
+++ b/src/Beckett.SourceGenerators/StateGenerator.cs
@@ -155,7 +155,7 @@ using Beckett;
 
 namespace {state.ContainingNamespace}
 {{
-    {state.AccessModifier} partial class {state.Name} : IApply
+    {state.AccessModifier} partial class {state.Name} : IApply, IApplyDiagnostics
     {{
         public void Apply(IMessageContext context)
         {{
@@ -164,6 +164,10 @@ namespace {state.ContainingNamespace}
                 {string.Join("\n", state.ApplyMethods.Select(MessageTypeSwitchCase))}
             }}
         }}
+
+        public Type[] AppliedMessageTypes => [
+            {string.Join(",\n", state.ApplyMethods.Select(MessageTypeArrayLine))}
+        ];
     }}
 }}
     ";
@@ -176,7 +180,7 @@ namespace {state.ContainingNamespace}
 {{
     {state.ContainingTypeAccessModifier} partial {(state.ContainingTypeIsRecord ? "record" : "class")} {state.ContainingTypeName}
     {{
-        {state.AccessModifier} partial class {state.Name} : IApply
+        {state.AccessModifier} partial class {state.Name} : IApply, IApplyDiagnostics
         {{
             public void Apply(IMessageContext context)
             {{
@@ -185,6 +189,10 @@ namespace {state.ContainingNamespace}
                     {string.Join("\n", state.ApplyMethods.Select(MessageTypeSwitchCase))}
                 }}
             }}
+
+            public Type[] AppliedMessageTypes => [
+                {string.Join(",\n", state.ApplyMethods.Select(MessageTypeArrayLine))}
+            ];
         }}
     }}
 }}
@@ -194,5 +202,9 @@ namespace {state.ContainingNamespace}
                 case {applyMethod.MessageType} m:
                     {(applyMethod.IncludeContext ? "Apply(m, context)" : "Apply(m)")};
                     break;
+";
+
+    private static string MessageTypeArrayLine(ApplyMethod applyMethod) => $@"
+                typeof({applyMethod.MessageType})
 ";
 }

--- a/src/Beckett.SourceGenerators/StateGenerator.cs
+++ b/src/Beckett.SourceGenerators/StateGenerator.cs
@@ -165,7 +165,7 @@ namespace {state.ContainingNamespace}
             }}
         }}
 
-        public Type[] AppliedMessageTypes => [
+        public Type[] AppliedMessageTypes() => [
             {string.Join(",\n", state.ApplyMethods.Select(MessageTypeArrayLine))}
         ];
     }}
@@ -190,7 +190,7 @@ namespace {state.ContainingNamespace}
                 }}
             }}
 
-            public Type[] AppliedMessageTypes => [
+            public Type[] AppliedMessageTypes() => [
                 {string.Join(",\n", state.ApplyMethods.Select(MessageTypeArrayLine))}
             ];
         }}

--- a/src/Beckett.Tests/Projections/ProjectionConfigurationTests.cs
+++ b/src/Beckett.Tests/Projections/ProjectionConfigurationTests.cs
@@ -1,0 +1,153 @@
+using System.Runtime.CompilerServices;
+using Beckett.Projections;
+
+namespace Beckett.Tests.Projections;
+
+public partial class ProjectionConfigurationTests
+{
+    public class when_configured_correctly
+    {
+        [Fact]
+        public void is_valid()
+        {
+            var projection =
+                (IProjection<TestReadModel, Guid>)RuntimeHelpers.GetUninitializedObject(
+                    typeof(TestReadModelProjection)
+                );
+
+            var configuration = new ProjectionConfiguration<Guid>();
+
+            projection.Configure(configuration);
+
+            try
+            {
+                configuration.Validate(new TestReadModel());
+            }
+            catch
+            {
+                Assert.Fail("Projection configuration should be valid");
+            }
+        }
+    }
+
+    public class when_message_type_is_applied_but_not_configured
+    {
+        [Fact]
+        public void throws()
+        {
+            var projection =
+                (IProjection<TestReadModel, Guid>)RuntimeHelpers.GetUninitializedObject(
+                    typeof(TestReadModelProjectionMissingConfiguration)
+                );
+
+            var configuration = new ProjectionConfiguration<Guid>();
+
+            projection.Configure(configuration);
+
+            var exception = Assert.Throws<Exception>(() => configuration.Validate(new TestReadModel()));
+            Assert.Contains("Applied but not configured", exception.Message);
+            Assert.Contains(typeof(TestUpdateMessage).FullName!, exception.Message);
+        }
+    }
+
+    public class when_message_type_is_configured_but_not_applied
+    {
+        [Fact]
+        public void throws()
+        {
+            var projection =
+                (IProjection<TestReadModel, Guid>)RuntimeHelpers.GetUninitializedObject(
+                    typeof(TestReadModelProjectionMissingApplyMethod)
+                );
+
+            var configuration = new ProjectionConfiguration<Guid>();
+
+            projection.Configure(configuration);
+
+            var exception = Assert.Throws<Exception>(() => configuration.Validate(new TestReadModel()));
+            Assert.Contains("Configured but not applied", exception.Message);
+            Assert.Contains(typeof(TestUpdateMessageNotApplied).FullName!, exception.Message);
+        }
+    }
+
+    [State]
+    public partial class TestReadModel
+    {
+        private void Apply(TestCreateMessage _)
+        {
+        }
+
+        private void Apply(TestUpdateMessage _)
+        {
+        }
+    }
+
+    public class TestReadModelProjection : IProjection<TestReadModel, Guid>
+    {
+        public void Configure(IProjectionConfiguration<Guid> configuration)
+        {
+            configuration.CreatedBy<TestCreateMessage>(x => x.Id);
+            configuration.UpdatedBy<TestUpdateMessage>(x => x.Id);
+        }
+
+        public Task Create(TestReadModel state, CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+
+        public Task<TestReadModel?> Read(Guid key, CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+
+        public Task Update(TestReadModel state, CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+
+        public Task Delete(TestReadModel state, CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+    }
+
+    public class TestReadModelProjectionMissingConfiguration : IProjection<TestReadModel, Guid>
+    {
+        public void Configure(IProjectionConfiguration<Guid> configuration)
+        {
+            configuration.CreatedBy<TestCreateMessage>(x => x.Id);
+        }
+
+        public Task Create(TestReadModel state, CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+
+        public Task<TestReadModel?> Read(Guid key, CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+
+        public Task Update(TestReadModel state, CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+
+        public Task Delete(TestReadModel state, CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+    }
+
+    public class TestReadModelProjectionMissingApplyMethod : IProjection<TestReadModel, Guid>
+    {
+        public void Configure(IProjectionConfiguration<Guid> configuration)
+        {
+            configuration.CreatedBy<TestCreateMessage>(x => x.Id);
+            configuration.UpdatedBy<TestUpdateMessage>(x => x.Id);
+            configuration.UpdatedBy<TestUpdateMessageNotApplied>(x => x.Id);
+        }
+
+        public Task Create(TestReadModel state, CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+
+        public Task<TestReadModel?> Read(Guid key, CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+
+        public Task Update(TestReadModel state, CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+
+        public Task Delete(TestReadModel state, CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+    }
+
+    public record TestCreateMessage(Guid Id);
+
+    public record TestUpdateMessage(Guid Id);
+
+    public record TestUpdateMessageNotApplied(Guid Id);
+}

--- a/src/Beckett.Tests/Projections/ProjectionHandlerTests.cs
+++ b/src/Beckett.Tests/Projections/ProjectionHandlerTests.cs
@@ -1,0 +1,375 @@
+using Beckett.Messages;
+using Beckett.Projections;
+
+namespace Beckett.Tests.Projections;
+
+public partial class ProjectionHandlerTests
+{
+    [Fact]
+    public async Task creates_projection()
+    {
+        var expectedId = Guid.NewGuid();
+        var projection = new TestReadModel.Projection();
+        var batch = new List<IMessageContext>
+        {
+            MessageContext.From(new TestCreateMessage(expectedId))
+        };
+
+        await ProjectionHandler<TestReadModel.Projection, TestReadModel, Guid>.Handle(
+            projection,
+            batch,
+            CancellationToken.None
+        );
+
+        Assert.Contains(expectedId, projection.Results.Keys);
+    }
+
+    [Fact]
+    public async Task updates_projection()
+    {
+        var expectedId = Guid.NewGuid();
+        var projection = new TestReadModel.Projection();
+        var batch = new List<IMessageContext>
+        {
+            MessageContext.From(new TestUpdateMessage(expectedId))
+        };
+        projection.Results.Add(expectedId, new TestReadModel
+        {
+            Id = expectedId,
+        });
+
+        await ProjectionHandler<TestReadModel.Projection, TestReadModel, Guid>.Handle(
+            projection,
+            batch,
+            CancellationToken.None
+        );
+
+        Assert.NotNull(projection.Results[expectedId]);
+        Assert.True(projection.Results[expectedId].Updated);
+    }
+
+    [Fact]
+    public async Task deletes_projection()
+    {
+        var expectedId = Guid.NewGuid();
+        var projection = new TestReadModel.Projection();
+        var batch = new List<IMessageContext>
+        {
+            MessageContext.From(new TestDeleteMessage(expectedId))
+        };
+        projection.Results.Add(expectedId, new TestReadModel
+        {
+            Id = expectedId,
+        });
+
+        await ProjectionHandler<TestReadModel.Projection, TestReadModel, Guid>.Handle(
+            projection,
+            batch,
+            CancellationToken.None
+        );
+
+        Assert.DoesNotContain(expectedId, projection.Results.Keys);
+    }
+
+    public class when_configured_to_create_or_update
+    {
+        public class when_projection_does_not_exist
+        {
+            [Fact]
+            public async Task creates_projection()
+            {
+                var expectedId = Guid.NewGuid();
+                var projection = new TestReadModel.Projection();
+                var batch = new List<IMessageContext>
+                {
+                    MessageContext.From(new TestCreateOrUpdateMessage(expectedId))
+                };
+
+                await ProjectionHandler<TestReadModel.Projection, TestReadModel, Guid>.Handle(
+                    projection,
+                    batch,
+                    CancellationToken.None
+                );
+
+                Assert.Contains(expectedId, projection.Results.Keys);
+            }
+        }
+
+        public class when_projection_exists
+        {
+            [Fact]
+            public async Task updates_projection()
+            {
+                var expectedId = Guid.NewGuid();
+                var projection = new TestReadModel.Projection();
+                var batch = new List<IMessageContext>
+                {
+                    MessageContext.From(new TestCreateOrUpdateMessage(expectedId))
+                };
+                projection.Results.Add(expectedId, new TestReadModel
+                {
+                    Id = expectedId,
+                });
+
+                await ProjectionHandler<TestReadModel.Projection, TestReadModel, Guid>.Handle(
+                    projection,
+                    batch,
+                    CancellationToken.None
+                );
+
+                Assert.True(projection.Results[expectedId].Updated);
+            }
+        }
+    }
+
+    public class when_configured_to_ignore_when_not_found
+    {
+        public class when_projection_exists
+        {
+            [Fact]
+            public async Task updates_projection()
+            {
+                var expectedId = Guid.NewGuid();
+                var projection = new TestReadModel.Projection();
+                var batch = new List<IMessageContext>
+                {
+                    MessageContext.From(new TestUpdateMessageWithIgnoreWhenNotFound(expectedId))
+                };
+                projection.Results.Add(expectedId, new TestReadModel
+                {
+                    Id = expectedId,
+                });
+
+                await ProjectionHandler<TestReadModel.Projection, TestReadModel, Guid>.Handle(
+                    projection,
+                    batch,
+                    CancellationToken.None
+                );
+
+                Assert.True(projection.Results[expectedId].Updated);
+            }
+
+            [Fact]
+            public async Task deletes_projection()
+            {
+                var expectedId = Guid.NewGuid();
+                var projection = new TestReadModel.Projection();
+                var batch = new List<IMessageContext>
+                {
+                    MessageContext.From(new TestDeleteMessageWithIgnoreWhenNotFound(expectedId))
+                };
+                projection.Results.Add(expectedId, new TestReadModel
+                {
+                    Id = expectedId,
+                });
+
+                await ProjectionHandler<TestReadModel.Projection, TestReadModel, Guid>.Handle(
+                    projection,
+                    batch,
+                    CancellationToken.None
+                );
+
+                Assert.DoesNotContain(expectedId, projection.Results.Keys);
+            }
+        }
+
+        public class when_projection_does_not_exist
+        {
+            [Fact]
+            public async Task creates_projection_for_update()
+            {
+                var expectedId = Guid.NewGuid();
+                var projection = new TestReadModel.Projection();
+                var batch = new List<IMessageContext>
+                {
+                    MessageContext.From(new TestUpdateMessageWithIgnoreWhenNotFound(expectedId))
+                };
+
+                await ProjectionHandler<TestReadModel.Projection, TestReadModel, Guid>.Handle(
+                    projection,
+                    batch,
+                    CancellationToken.None
+                );
+
+                Assert.Contains(expectedId, projection.Results.Keys);
+            }
+
+            [Fact]
+            public async Task does_nothing_for_delete()
+            {
+                var expectedId = Guid.NewGuid();
+                var projection = new TestReadModel.Projection();
+                var batch = new List<IMessageContext>
+                {
+                    MessageContext.From(new TestDeleteMessageWithIgnoreWhenNotFound(expectedId))
+                };
+
+                await ProjectionHandler<TestReadModel.Projection, TestReadModel, Guid>.Handle(
+                    projection,
+                    batch,
+                    CancellationToken.None
+                );
+
+                Assert.Empty(projection.Results.Keys);
+            }
+        }
+    }
+
+    public class when_projection_can_produce_more_than_one_result_per_batch
+    {
+        [Fact]
+        public async Task stores_multiple_results()
+        {
+            var today = DateOnly.FromDateTime(DateTime.Today);
+            var projection = new ReadModelWithCompositeKey.Projection();
+            var expectedKey1 = ReadModelWithCompositeKey.IdFor(1, today);
+            var expectedKey2 = ReadModelWithCompositeKey.IdFor(2, today);
+            var batch = new List<IMessageContext>
+            {
+                MessageContext.From(new TestMessageWithCompositeKey(1, today)),
+                MessageContext.From(new TestMessageWithCompositeKey(2, today))
+            };
+
+            await ProjectionHandler<ReadModelWithCompositeKey.Projection, ReadModelWithCompositeKey, string>.Handle(
+                projection,
+                batch,
+                CancellationToken.None
+            );
+
+            Assert.Contains(expectedKey1, projection.Results.Keys);
+            Assert.Contains(expectedKey2, projection.Results.Keys);
+        }
+    }
+
+    [State]
+    public partial class TestReadModel
+    {
+        public Guid Id { get; set; }
+        public bool Updated { get; private set; }
+
+        private void Apply(TestCreateMessage m)
+        {
+            Id = m.Id;
+        }
+
+        private void Apply(TestCreateOrUpdateMessage m)
+        {
+            Id = m.Id;
+            Updated = true;
+        }
+
+        private void Apply(TestUpdateMessage m)
+        {
+            Id = m.Id;
+            Updated = true;
+        }
+
+        private void Apply(TestUpdateMessageWithIgnoreWhenNotFound m)
+        {
+            Id = m.Id;
+            Updated = true;
+        }
+
+        public class Projection : IProjection<TestReadModel, Guid>
+        {
+            public readonly Dictionary<Guid, TestReadModel> Results = [];
+
+            public void Configure(IProjectionConfiguration<Guid> configuration)
+            {
+                configuration.CreatedBy<TestCreateMessage>(x => x.Id);
+                configuration.CreatedOrUpdatedBy<TestCreateOrUpdateMessage>(x => x.Id);
+                configuration.UpdatedBy<TestUpdateMessage>(x => x.Id);
+                configuration.UpdatedBy<TestUpdateMessageWithIgnoreWhenNotFound>(x => x.Id).IgnoreWhenNotFound();
+                configuration.DeletedBy<TestDeleteMessage>(x => x.Id);
+                configuration.DeletedBy<TestDeleteMessageWithIgnoreWhenNotFound>(x => x.Id).IgnoreWhenNotFound();
+            }
+
+            public Task Create(TestReadModel state, CancellationToken cancellationToken)
+            {
+                Results.Add(state.Id, state);
+
+                return Task.CompletedTask;
+            }
+
+            public Task<TestReadModel?> Read(Guid key, CancellationToken cancellationToken)
+            {
+                return Task.FromResult(Results.GetValueOrDefault(key));
+            }
+
+            public Task Update(TestReadModel state, CancellationToken cancellationToken)
+            {
+                Results[state.Id] = state;
+
+                return Task.CompletedTask;
+            }
+
+            public Task Delete(TestReadModel state, CancellationToken cancellationToken)
+            {
+                Results.Remove(state.Id);
+
+                return Task.CompletedTask;
+            }
+        }
+    }
+
+    [State]
+    public partial class ReadModelWithCompositeKey
+    {
+        private string CompositeKey => IdFor(Id, Date);
+        private int Id { get; set; }
+        private DateOnly Date { get; set; }
+
+        public static string IdFor(int id, DateOnly date) => $"{id}#{date}";
+
+        private void Apply(TestMessageWithCompositeKey m)
+        {
+            Id = m.Id;
+            Date = m.Date;
+        }
+
+        public class Projection : IProjection<ReadModelWithCompositeKey, string>
+        {
+            public readonly Dictionary<string, ReadModelWithCompositeKey> Results = [];
+
+            public void Configure(IProjectionConfiguration<string> configuration)
+            {
+                configuration.CreatedBy<TestMessageWithCompositeKey>(x => IdFor(x.Id, x.Date));
+            }
+
+            public Task Create(ReadModelWithCompositeKey state, CancellationToken cancellationToken)
+            {
+                Results.Add(state.CompositeKey, state);
+
+                return Task.CompletedTask;
+            }
+
+            public Task<ReadModelWithCompositeKey?> Read(string key, CancellationToken cancellationToken)
+            {
+                return Task.FromResult(Results.GetValueOrDefault(key));
+            }
+
+            public Task Update(ReadModelWithCompositeKey state, CancellationToken cancellationToken)
+            {
+                Results[state.CompositeKey] = state;
+
+                return Task.CompletedTask;
+            }
+
+            public Task Delete(ReadModelWithCompositeKey state, CancellationToken cancellationToken)
+            {
+                Results.Remove(state.CompositeKey);
+
+                return Task.CompletedTask;
+            }
+        }
+    }
+
+    public record TestCreateMessage(Guid Id);
+    public record TestCreateOrUpdateMessage(Guid Id);
+    public record TestUpdateMessage(Guid Id);
+    public record TestUpdateMessageWithIgnoreWhenNotFound(Guid Id);
+    public record TestDeleteMessage(Guid Id);
+    public record TestDeleteMessageWithIgnoreWhenNotFound(Guid Id);
+
+    public record TestMessageWithCompositeKey(int Id, DateOnly Date);
+}

--- a/src/Beckett.Tests/Projections/ProjectionHandlerTests.cs
+++ b/src/Beckett.Tests/Projections/ProjectionHandlerTests.cs
@@ -148,29 +148,6 @@ public partial class ProjectionHandlerTests
 
                 Assert.True(projection.Results[expectedId].Updated);
             }
-
-            [Fact]
-            public async Task deletes_projection()
-            {
-                var expectedId = Guid.NewGuid();
-                var projection = new TestReadModel.Projection();
-                var batch = new List<IMessageContext>
-                {
-                    MessageContext.From(new TestDeleteMessageWithIgnoreWhenNotFound(expectedId))
-                };
-                projection.Results.Add(expectedId, new TestReadModel
-                {
-                    Id = expectedId,
-                });
-
-                await ProjectionHandler<TestReadModel.Projection, TestReadModel, Guid>.Handle(
-                    projection,
-                    batch,
-                    CancellationToken.None
-                );
-
-                Assert.DoesNotContain(expectedId, projection.Results.Keys);
-            }
         }
 
         public class when_projection_does_not_exist
@@ -192,25 +169,6 @@ public partial class ProjectionHandlerTests
                 );
 
                 Assert.Contains(expectedId, projection.Results.Keys);
-            }
-
-            [Fact]
-            public async Task does_nothing_for_delete()
-            {
-                var expectedId = Guid.NewGuid();
-                var projection = new TestReadModel.Projection();
-                var batch = new List<IMessageContext>
-                {
-                    MessageContext.From(new TestDeleteMessageWithIgnoreWhenNotFound(expectedId))
-                };
-
-                await ProjectionHandler<TestReadModel.Projection, TestReadModel, Guid>.Handle(
-                    projection,
-                    batch,
-                    CancellationToken.None
-                );
-
-                Assert.Empty(projection.Results.Keys);
             }
         }
     }
@@ -281,7 +239,6 @@ public partial class ProjectionHandlerTests
                 configuration.UpdatedBy<TestUpdateMessage>(x => x.Id);
                 configuration.UpdatedBy<TestUpdateMessageWithIgnoreWhenNotFound>(x => x.Id).IgnoreWhenNotFound();
                 configuration.DeletedBy<TestDeleteMessage>(x => x.Id);
-                configuration.DeletedBy<TestDeleteMessageWithIgnoreWhenNotFound>(x => x.Id).IgnoreWhenNotFound();
             }
 
             public Task Create(TestReadModel state, CancellationToken cancellationToken)
@@ -369,7 +326,5 @@ public partial class ProjectionHandlerTests
     public record TestUpdateMessage(Guid Id);
     public record TestUpdateMessageWithIgnoreWhenNotFound(Guid Id);
     public record TestDeleteMessage(Guid Id);
-    public record TestDeleteMessageWithIgnoreWhenNotFound(Guid Id);
-
     public record TestMessageWithCompositeKey(int Id, DateOnly Date);
 }

--- a/src/Beckett.Tests/SourceGenerators/StateGeneratorTests.cs
+++ b/src/Beckett.Tests/SourceGenerators/StateGeneratorTests.cs
@@ -25,7 +25,7 @@ public class StateGeneratorTests
             var state = new TestState();
 
             Assert.Collection(
-                state.AppliedMessageTypes,
+                state.AppliedMessageTypes(),
                 type => Assert.Equal(typeof(TestMessage), type),
                 type => Assert.Equal(typeof(TestMessageWithContext), type)
             );

--- a/src/Beckett.Tests/SourceGenerators/StateGeneratorTests.cs
+++ b/src/Beckett.Tests/SourceGenerators/StateGeneratorTests.cs
@@ -20,6 +20,18 @@ public class StateGeneratorTests
         }
 
         [Fact]
+        public void applied_message_types_are_available()
+        {
+            var state = new TestState();
+
+            Assert.Collection(
+                state.AppliedMessageTypes,
+                type => Assert.Equal(typeof(TestMessage), type),
+                type => Assert.Equal(typeof(TestMessageWithContext), type)
+            );
+        }
+
+        [Fact]
         public void applies_message()
         {
             var state = new TestState();

--- a/src/Beckett/Configuration/SubscriptionConfigurationBuilder.cs
+++ b/src/Beckett/Configuration/SubscriptionConfigurationBuilder.cs
@@ -79,6 +79,8 @@ public class SubscriptionConfigurationBuilder(
 
         projection.Configure(configuration);
 
+        configuration.Validate(new TState());
+
         Messages(configuration.GetMessageTypes());
 
         subscription.HandlerDelegate = ProjectionHandler<TProjection, TState, TKey>.Handle;

--- a/src/Beckett/IApply.cs
+++ b/src/Beckett/IApply.cs
@@ -25,3 +25,11 @@ public interface IApply
 {
     void Apply(IMessageContext context);
 }
+
+/// <summary>
+/// Internal interface used by the source generator to provide startup diagnostics for projections
+/// </summary>
+public interface IApplyDiagnostics
+{
+    Type[] AppliedMessageTypes { get; }
+}

--- a/src/Beckett/IApply.cs
+++ b/src/Beckett/IApply.cs
@@ -31,5 +31,5 @@ public interface IApply
 /// </summary>
 public interface IApplyDiagnostics
 {
-    Type[] AppliedMessageTypes { get; }
+    Type[] AppliedMessageTypes();
 }

--- a/src/Beckett/Projections/IHandleApply.cs
+++ b/src/Beckett/Projections/IHandleApply.cs
@@ -1,6 +1,0 @@
-namespace Beckett.Projections;
-
-public interface IHandleApply<T> where T : IApply, new()
-{
-    Task<T> Apply(T state, IMessageContext context, CancellationToken cancellationToken);
-}

--- a/src/Beckett/Projections/IProjectionConfiguration.cs
+++ b/src/Beckett/Projections/IProjectionConfiguration.cs
@@ -87,6 +87,8 @@ public class ProjectionConfiguration<TKey> : IProjectionConfiguration<TKey>
         return batch.Where(x => x.MessageType != null && _map.ContainsKey(x.MessageType)).ToList();
     }
 
+    public TKey GetKey(IMessageContext context) => GetConfigurationFor(context.MessageType!).Key(context.Message!);
+
     public ProjectionMessageConfiguration<TKey> GetConfigurationFor(Type messageType) => _map[messageType];
 
     private Type[] GetMessageTypesExcludingDeletedBy() =>

--- a/src/Beckett/Projections/IProjectionConfiguration.cs
+++ b/src/Beckett/Projections/IProjectionConfiguration.cs
@@ -4,32 +4,32 @@ namespace Beckett.Projections;
 
 public interface IProjectionConfiguration<TKey>
 {
-    IProjectionMessageConfiguration<TKey> CreatedBy<TMessage>(Func<TMessage, TKey> key);
-    IProjectionMessageConfiguration<TKey> CreatedOrUpdatedBy<TMessage>(Func<TMessage, TKey> key);
-    IProjectionMessageConfiguration<TKey> UpdatedBy<TMessage>(Func<TMessage, TKey> key);
-    IProjectionMessageConfiguration<TKey> DeletedBy<TMessage>(Func<TMessage, TKey> key);
+    IProjectionMessageConfiguration<TMessage, TKey> CreatedBy<TMessage>(Func<TMessage, TKey> key);
+    IProjectionMessageConfiguration<TMessage, TKey> CreatedOrUpdatedBy<TMessage>(Func<TMessage, TKey> key);
+    IProjectionMessageConfiguration<TMessage, TKey> UpdatedBy<TMessage>(Func<TMessage, TKey> key);
+    IProjectionMessageConfiguration<TMessage, TKey> DeletedBy<TMessage>(Func<TMessage, TKey> key);
 }
 
 public class ProjectionConfiguration<TKey> : IProjectionConfiguration<TKey>
 {
-    private readonly Dictionary<Type, ProjectionMessageConfiguration<TKey>> _map = new();
+    private readonly Dictionary<Type, ProjectionMessageConfiguration> _map = new();
 
-    public IProjectionMessageConfiguration<TKey> CreatedBy<TMessage>(Func<TMessage, TKey> key)
+    public IProjectionMessageConfiguration<TMessage, TKey> CreatedBy<TMessage>(Func<TMessage, TKey> key)
     {
         return RegisterMessageConfiguration(ProjectionAction.Create, key);
     }
 
-    public IProjectionMessageConfiguration<TKey> CreatedOrUpdatedBy<TMessage>(Func<TMessage, TKey> key)
+    public IProjectionMessageConfiguration<TMessage, TKey> CreatedOrUpdatedBy<TMessage>(Func<TMessage, TKey> key)
     {
         return RegisterMessageConfiguration(ProjectionAction.CreateOrUpdate, key);
     }
 
-    public IProjectionMessageConfiguration<TKey> UpdatedBy<TMessage>(Func<TMessage, TKey> key)
+    public IProjectionMessageConfiguration<TMessage, TKey> UpdatedBy<TMessage>(Func<TMessage, TKey> key)
     {
         return RegisterMessageConfiguration(ProjectionAction.Update, key);
     }
 
-    public IProjectionMessageConfiguration<TKey> DeletedBy<TMessage>(Func<TMessage, TKey> key)
+    public IProjectionMessageConfiguration<TMessage, TKey> DeletedBy<TMessage>(Func<TMessage, TKey> key)
     {
         return RegisterMessageConfiguration(ProjectionAction.Delete, key);
     }
@@ -84,26 +84,28 @@ public class ProjectionConfiguration<TKey> : IProjectionConfiguration<TKey>
 
     public IReadOnlyList<IMessageContext> Filter(IReadOnlyList<IMessageContext> batch)
     {
-        return batch.Where(x => x.MessageType != null && _map.ContainsKey(x.MessageType)).ToList();
+        return batch.Where(x => x.MessageType != null && _map.ContainsKey(x.MessageType))
+            .Where(x => !_map[x.MessageType!].IgnoreFilter(x.Message!)).ToList();
     }
 
-    public TKey GetKey(IMessageContext context) => GetConfigurationFor(context.MessageType!).Key(context.Message!);
+    public TKey GetKey(IMessageContext context) =>
+        (TKey)GetConfigurationFor(context.MessageType!).Key(context.Message!);
 
-    public ProjectionMessageConfiguration<TKey> GetConfigurationFor(Type messageType) => _map[messageType];
+    public ProjectionMessageConfiguration GetConfigurationFor(Type messageType) => _map[messageType];
 
     private Type[] GetMessageTypesExcludingDeletedBy() =>
         _map.Where(x => x.Value.Action != ProjectionAction.Delete).Select(x => x.Key).ToArray();
 
-    private ProjectionMessageConfiguration<TKey> RegisterMessageConfiguration<TMessage>(
+    private ProjectionMessageConfiguration<TMessage, TKey> RegisterMessageConfiguration<TMessage>(
         ProjectionAction action,
         Func<TMessage, TKey> key
     )
     {
         var messageType = typeof(TMessage);
 
-        var messageConfiguration = ProjectionMessageConfiguration<TKey>.Create(action, key);
+        var messageConfiguration = ProjectionMessageConfiguration<TMessage, TKey>.Create(action, key);
 
-        _map.TryAdd(messageType, messageConfiguration);
+        _map.TryAdd(messageType, messageConfiguration.Configuration);
 
         return messageConfiguration;
     }

--- a/src/Beckett/Projections/IProjectionConfiguration.cs
+++ b/src/Beckett/Projections/IProjectionConfiguration.cs
@@ -44,7 +44,7 @@ public class ProjectionConfiguration<TKey> : IProjectionConfiguration<TKey>
         }
 
         var configuredMessageTypes = GetMessageTypesExcludingDeletedBy().ToArray();
-        var appliedMessageTypes = diagnostics.AppliedMessageTypes;
+        var appliedMessageTypes = diagnostics.AppliedMessageTypes();
 
         if (configuredMessageTypes.Length == appliedMessageTypes.Length)
         {

--- a/src/Beckett/Projections/IProjectionConfiguration.cs
+++ b/src/Beckett/Projections/IProjectionConfiguration.cs
@@ -1,3 +1,5 @@
+using System.Text;
+
 namespace Beckett.Projections;
 
 public interface IProjectionConfiguration<TKey>
@@ -34,12 +36,61 @@ public class ProjectionConfiguration<TKey> : IProjectionConfiguration<TKey>
 
     public IReadOnlyList<Type> GetMessageTypes() => _map.Keys.ToArray();
 
+    public void Validate<TState>(TState state)
+    {
+        if (state is not IApplyDiagnostics diagnostics)
+        {
+            return;
+        }
+
+        var configuredMessageTypes = GetMessageTypesExcludingDeletedBy().ToArray();
+        var appliedMessageTypes = diagnostics.AppliedMessageTypes;
+
+        if (configuredMessageTypes.Length == appliedMessageTypes.Length)
+        {
+            return;
+        }
+
+        var errorMessage = new StringBuilder();
+
+        var appliedButNotConfigured = appliedMessageTypes.Except(configuredMessageTypes).ToArray();
+
+        if (appliedButNotConfigured.Length > 0)
+        {
+            errorMessage.AppendLine("Applied but not configured:");
+
+            foreach (var eventType in appliedButNotConfigured)
+            {
+                errorMessage.AppendLine(eventType.FullName);
+            }
+        }
+
+        var configuredButNotApplied = configuredMessageTypes.Except(appliedMessageTypes).ToArray();
+
+        if (configuredButNotApplied.Length > 0)
+        {
+            errorMessage.AppendLine("Configured but not applied:");
+
+            foreach (var eventType in configuredButNotApplied)
+            {
+                errorMessage.AppendLine(eventType.FullName);
+            }
+        }
+
+        var message = $"{typeof(TState).Name} projection is not configured correctly:\n\n{errorMessage}";
+
+        throw new Exception(message);
+    }
+
     public IReadOnlyList<IMessageContext> Filter(IReadOnlyList<IMessageContext> batch)
     {
         return batch.Where(x => x.MessageType != null && _map.ContainsKey(x.MessageType)).ToList();
     }
 
     public ProjectionMessageConfiguration<TKey> GetConfigurationFor(Type messageType) => _map[messageType];
+
+    private Type[] GetMessageTypesExcludingDeletedBy() =>
+        _map.Where(x => x.Value.Action != ProjectionAction.Delete).Select(x => x.Key).ToArray();
 
     private ProjectionMessageConfiguration<TKey> RegisterMessageConfiguration<TMessage>(
         ProjectionAction action,

--- a/src/Beckett/Projections/IProjectionMessageConfiguration.cs
+++ b/src/Beckett/Projections/IProjectionMessageConfiguration.cs
@@ -1,31 +1,53 @@
 namespace Beckett.Projections;
 
-public interface IProjectionMessageConfiguration<TKey>
+public interface IProjectionMessageConfiguration<out TMessage, TKey>
 {
-    IProjectionMessageConfiguration<TKey> IgnoreWhenNotFound();
+    IProjectionMessageConfiguration<TMessage, TKey> IgnoreWhenNotFound();
+    IProjectionMessageConfiguration<TMessage, TKey> IgnoreWhen(Predicate<TMessage> predicate);
 }
 
-public class ProjectionMessageConfiguration<TKey>(
-    ProjectionAction action,
-    Func<object, TKey> key
-) : IProjectionMessageConfiguration<TKey>
+public class ProjectionMessageConfiguration<TMessage, TKey> : IProjectionMessageConfiguration<TMessage, TKey>
 {
-    internal ProjectionAction Action { get; } = action;
-    internal Func<object, TKey> Key { get; } = key;
-    internal bool IgnoreIfNotFound { get; private set; }
+    private ProjectionMessageConfiguration(
+        ProjectionAction action,
+        Func<object, TKey> key
+    )
+    {
+        Configuration.Action = action;
+        Configuration.Key = x => key(x)!;
+    }
 
-    internal static ProjectionMessageConfiguration<TKey> Create<TMessage>(
+    internal ProjectionMessageConfiguration Configuration { get; } = new();
+
+    internal static ProjectionMessageConfiguration<TMessage, TKey> Create(
         ProjectionAction action,
         Func<TMessage, TKey> keySelector
     )
     {
-        return new ProjectionMessageConfiguration<TKey>(action, x => keySelector((TMessage)x));
+        return new ProjectionMessageConfiguration<TMessage, TKey>(action, x => keySelector((TMessage)x));
     }
 
-    public IProjectionMessageConfiguration<TKey> IgnoreWhenNotFound()
+    public IProjectionMessageConfiguration<TMessage, TKey> IgnoreWhenNotFound()
     {
-        IgnoreIfNotFound = true;
+        Configuration.IgnoreWhenNotFound = true;
 
         return this;
     }
+
+    public IProjectionMessageConfiguration<TMessage, TKey> IgnoreWhen(Predicate<TMessage> predicate)
+    {
+        Configuration.IgnoreFilter = x => predicate((TMessage)x);
+
+        return this;
+    }
+}
+
+public class ProjectionMessageConfiguration
+{
+    internal ProjectionAction Action { get; set; }
+    internal Func<object, object> Key { get; set; } = null!;
+    internal bool IgnoreWhenNotFound { get; set; }
+    internal Predicate<object> IgnoreFilter { get; set; } = _ => false;
+
+    internal TKey GetKey<TKey>(object message) => (TKey)Key(message);
 }

--- a/src/Beckett/Projections/ProjectionHandler.cs
+++ b/src/Beckett/Projections/ProjectionHandler.cs
@@ -20,28 +20,28 @@ public static class ProjectionHandler<TProjection, TState, TKey> where TProjecti
             return;
         }
 
-        var startingMessage = messagesToApply[0];
+        var firstMessage = messagesToApply[0];
         var lastMessage = messagesToApply[^1];
 
-        var startingMessageType = startingMessage.MessageType ??
-                                  throw new InvalidOperationException(
-                                      $"Unable to deserialize message of type {startingMessage.Type}"
-                                  );
+        var firstMessageType = firstMessage.MessageType ??
+                               throw new InvalidOperationException(
+                                   $"Unable to deserialize message of type {firstMessage.Type}"
+                               );
 
         var lastMessageType = lastMessage.MessageType ??
                               throw new InvalidOperationException(
                                   $"Unable to deserialize message of type {lastMessage.Type}"
                               );
 
-        var startingMessageConfiguration = configuration.GetConfigurationFor(startingMessageType);
+        var firstMessageConfiguration = configuration.GetConfigurationFor(firstMessageType);
         var lastMessageConfiguration = configuration.GetConfigurationFor(lastMessageType);
 
-        var actionToPerform = startingMessageConfiguration.Action;
-        var ignoreIfNotFound = startingMessageConfiguration.IgnoreIfNotFound;
+        var actionToPerform = firstMessageConfiguration.Action;
+        var ignoreIfNotFound = firstMessageConfiguration.IgnoreIfNotFound;
 
-        var key = startingMessageConfiguration.Key(
-            startingMessage.Message ??
-            throw new InvalidOperationException($"Unable to deserialize message of type {startingMessage.Type}")
+        var key = firstMessageConfiguration.Key(
+            firstMessage.Message ??
+            throw new InvalidOperationException($"Unable to deserialize message of type {firstMessage.Type}")
         );
 
         if (lastMessageConfiguration.Action == ProjectionAction.Delete)

--- a/src/Beckett/Projections/ProjectionHandler.cs
+++ b/src/Beckett/Projections/ProjectionHandler.cs
@@ -53,19 +53,7 @@ public static class ProjectionHandler<TProjection, TState, TKey> where TProjecti
 
         var result = await LoadState(projection, key, actionToPerform, ignoreIfNotFound, cancellationToken);
 
-        var state = result.State;
-
-        if (projection is IHandleApply<TState> applyHandler)
-        {
-            foreach (var message in messagesToApply)
-            {
-                state = await applyHandler.Apply(state, message, cancellationToken);
-            }
-        }
-        else
-        {
-            state = messagesToApply.ApplyTo(state);
-        }
+        var state = messagesToApply.ApplyTo(result.State);
 
         if (actionToPerform == ProjectionAction.Create)
         {


### PR DESCRIPTION
- add startup configuration validation to prevent issue where there is an `Apply` method for a message type but projection does not have it configured as a `CreatedBy`, `UpdatedBy`, etc... and the reverse - a message type is configured but not applied
- handle multiple results per batch - most common when projections have a composite key - in that situation a batch of events from a single stream could result in multiple results
- add ignore filter support
- drop `IHandleApply` interceptor - permits bad behavior such as making external calls while applying messages inside a projection