### PR TITLE
Projections - delete by key instead of read + delete

### DIFF
--- a/samples/TaskHub/TaskHub/TaskLists/Slices/GetLists/GetListsReadModelProjection.cs
+++ b/samples/TaskHub/TaskHub/TaskLists/Slices/GetLists/GetListsReadModelProjection.cs
@@ -59,13 +59,13 @@ public class GetListsReadModelProjection(NpgsqlDataSource dataSource) : IProject
         await command.ExecuteNonQueryAsync(cancellationToken);
     }
 
-    public async Task Delete(GetListsReadModel state, CancellationToken cancellationToken)
+    public async Task Delete(Guid key, CancellationToken cancellationToken)
     {
         const string sql = "DELETE FROM task_lists.get_lists_read_model WHERE id = $1;";
 
         var command = dataSource.CreateCommand(sql);
 
-        command.Parameters.AddWithValue(state.Id);
+        command.Parameters.AddWithValue(key);
 
         await command.ExecuteNonQueryAsync(cancellationToken);
     }

--- a/samples/TaskHub/TaskHub/TaskLists/Slices/GetLists/Tests/GetListsIntegrationTests.cs
+++ b/samples/TaskHub/TaskHub/TaskLists/Slices/GetLists/Tests/GetListsIntegrationTests.cs
@@ -55,7 +55,7 @@ public class GetListsIntegrationTests(DatabaseFixture database) : IClassFixture<
         var projection = new GetListsReadModelProjection(database.DataSource);
         await projection.Create(state, CancellationToken.None);
 
-        await projection.Delete(state, CancellationToken.None);
+        await projection.Delete(state.Id, CancellationToken.None);
 
         var readModel = await projection.Read(state.Id, CancellationToken.None);
         Assert.Null(readModel);

--- a/samples/TaskHub/TaskHub/Users/Slices/GetUsers/GetUsersReadModelProjection.cs
+++ b/samples/TaskHub/TaskHub/Users/Slices/GetUsers/GetUsersReadModelProjection.cs
@@ -49,13 +49,13 @@ public class GetUsersReadModelProjection(NpgsqlDataSource dataSource) : IProject
     public Task Update(GetUsersReadModel state, CancellationToken cancellationToken) =>
         throw new NotImplementedException();
 
-    public async Task Delete(GetUsersReadModel state, CancellationToken cancellationToken)
+    public async Task Delete(string key, CancellationToken cancellationToken)
     {
         const string sql = "DELETE FROM users.get_users_read_model WHERE username = $1;";
 
         var command = dataSource.CreateCommand(sql);
 
-        command.Parameters.AddWithValue(state.Username);
+        command.Parameters.AddWithValue(key);
 
         await command.ExecuteNonQueryAsync(cancellationToken);
     }

--- a/samples/TaskHub/TaskHub/Users/Slices/GetUsers/Tests/GetUsersIntegrationTests.cs
+++ b/samples/TaskHub/TaskHub/Users/Slices/GetUsers/Tests/GetUsersIntegrationTests.cs
@@ -25,7 +25,7 @@ public class GetUsersIntegrationTests(DatabaseFixture database) : IClassFixture<
         var projection = new GetUsersReadModelProjection(database.DataSource);
         await projection.Create(state, CancellationToken.None);
 
-        await projection.Delete(state, CancellationToken.None);
+        await projection.Delete(state.Username, CancellationToken.None);
 
         var readModel = await projection.Read(state.Username, CancellationToken.None);
         Assert.Null(readModel);

--- a/src/Beckett.Tests/Projections/ProjectionConfigurationTests.cs
+++ b/src/Beckett.Tests/Projections/ProjectionConfigurationTests.cs
@@ -122,7 +122,7 @@ public partial class ProjectionConfigurationTests
         public Task Update(TestReadModel state, CancellationToken cancellationToken) =>
             throw new NotImplementedException();
 
-        public Task Delete(TestReadModel state, CancellationToken cancellationToken) =>
+        public Task Delete(Guid key, CancellationToken cancellationToken) =>
             throw new NotImplementedException();
     }
 
@@ -142,7 +142,7 @@ public partial class ProjectionConfigurationTests
         public Task Update(TestReadModel state, CancellationToken cancellationToken) =>
             throw new NotImplementedException();
 
-        public Task Delete(TestReadModel state, CancellationToken cancellationToken) =>
+        public Task Delete(Guid key, CancellationToken cancellationToken) =>
             throw new NotImplementedException();
     }
 
@@ -164,7 +164,7 @@ public partial class ProjectionConfigurationTests
         public Task Update(TestReadModel state, CancellationToken cancellationToken) =>
             throw new NotImplementedException();
 
-        public Task Delete(TestReadModel state, CancellationToken cancellationToken) =>
+        public Task Delete(Guid key, CancellationToken cancellationToken) =>
             throw new NotImplementedException();
     }
 

--- a/src/Beckett.Tests/Projections/ProjectionHandlerTests.cs
+++ b/src/Beckett.Tests/Projections/ProjectionHandlerTests.cs
@@ -260,9 +260,9 @@ public partial class ProjectionHandlerTests
                 return Task.CompletedTask;
             }
 
-            public Task Delete(TestReadModel state, CancellationToken cancellationToken)
+            public Task Delete(Guid key, CancellationToken cancellationToken)
             {
-                Results.Remove(state.Id);
+                Results.Remove(key);
 
                 return Task.CompletedTask;
             }
@@ -312,9 +312,9 @@ public partial class ProjectionHandlerTests
                 return Task.CompletedTask;
             }
 
-            public Task Delete(ReadModelWithCompositeKey state, CancellationToken cancellationToken)
+            public Task Delete(string key, CancellationToken cancellationToken)
             {
-                Results.Remove(state.CompositeKey);
+                Results.Remove(key);
 
                 return Task.CompletedTask;
             }

--- a/src/Beckett/Projections/IProjection.cs
+++ b/src/Beckett/Projections/IProjection.cs
@@ -6,5 +6,5 @@ public interface IProjection<T, TKey> where T : IApply, new()
     Task Create(T state, CancellationToken cancellationToken);
     Task<T?> Read(TKey key, CancellationToken cancellationToken);
     Task Update(T state, CancellationToken cancellationToken);
-    Task Delete(T state, CancellationToken cancellationToken);
+    Task Delete(TKey key, CancellationToken cancellationToken);
 }

--- a/src/Beckett/Projections/ProjectionHandler.cs
+++ b/src/Beckett/Projections/ProjectionHandler.cs
@@ -120,13 +120,6 @@ public static class ProjectionHandler<TProjection, TState, TKey> where TProjecti
             return;
         }
 
-        var state = await projection.Read(key, cancellationToken);
-
-        if (state == null)
-        {
-            return;
-        }
-
-        await projection.Delete(state, cancellationToken);
+        await projection.Delete(key, cancellationToken);
     }
 }


### PR DESCRIPTION
- get rid of unnecessary read in delete handling for projections - just delete by key instead of read + delete