### PR TITLE
Checkpoint polling update

### DIFF
--- a/db/migrations/001.sql
+++ b/db/migrations/001.sql
@@ -633,7 +633,8 @@ AS
 $$
 BEGIN
   UPDATE __schema__.checkpoints
-  SET reserved_until = NULL
+  SET process_at = NULL,
+      reserved_until = NULL
   WHERE id = _id;
 END;
 $$;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -578,7 +578,8 @@ CREATE FUNCTION beckett.release_checkpoint_reservation(_id bigint) RETURNS void
     AS $$
 BEGIN
   UPDATE beckett.checkpoints
-  SET reserved_until = NULL
+  SET process_at = NULL,
+      reserved_until = NULL
   WHERE id = _id;
 END;
 $$;

--- a/samples/TaskHub/TaskHub/TaskLists/TaskListModule.cs
+++ b/samples/TaskHub/TaskHub/TaskLists/TaskListModule.cs
@@ -51,7 +51,7 @@ public class TaskListModule : IBeckettModule, IConfigureRoutes
             .Handler(
                 (IMessageContext context) =>
                 {
-                    Console.WriteLine($"[MESSAGE] category: {Category}, stream: {context.StreamName}, type: {context.Type}, id: {context.Id}");
+                    Console.WriteLine($"[MESSAGE] category: {Category}, stream: {context.StreamName}, type: {context.Type}, id: {context.Id} [lag: {DateTimeOffset.UtcNow.Subtract(context.Timestamp).TotalMilliseconds} ms]");
 
                     return Task.CompletedTask;
                 }

--- a/samples/TaskHub/TaskHub/Users/UserModule.cs
+++ b/samples/TaskHub/TaskHub/Users/UserModule.cs
@@ -40,7 +40,7 @@ public class UserModule : IBeckettModule, IConfigureRoutes
             .Handler(
                 (IMessageContext context) =>
                 {
-                    Console.WriteLine($"[MESSAGE] category: {Category}, stream: {context.StreamName}, type: {context.Type}, id: {context.Id}");
+                    Console.WriteLine($"[MESSAGE] category: {Category}, stream: {context.StreamName}, type: {context.Type}, id: {context.Id} [lag: {DateTimeOffset.UtcNow.Subtract(context.Timestamp).TotalMilliseconds} ms]");
 
                     return Task.CompletedTask;
                 }

--- a/src/Beckett/Subscriptions/CheckpointConsumer.cs
+++ b/src/Beckett/Subscriptions/CheckpointConsumer.cs
@@ -7,7 +7,7 @@ namespace Beckett.Subscriptions;
 
 public class CheckpointConsumer(
     Channel<CheckpointAvailable> channel,
-    int instance,
+    int consumer,
     IPostgresDatabase database,
     ICheckpointProcessor checkpointProcessor,
     BeckettOptions options,
@@ -16,76 +16,81 @@ public class CheckpointConsumer(
 {
     public async Task StartPolling(CancellationToken cancellationToken)
     {
-        logger.StartingCheckpointPolling(instance);
+        logger.StartingCheckpointPolling(consumer);
 
         while (await channel.Reader.WaitToReadAsync(cancellationToken))
         {
-            try
+            while (channel.Reader.TryRead(out _))
             {
-                if (!channel.Reader.TryRead(out _))
+                try
                 {
-                    continue;
-                }
+                    cancellationToken.ThrowIfCancellationRequested();
 
-                cancellationToken.ThrowIfCancellationRequested();
+                    logger.AttemptingToReserveCheckpoint(consumer);
 
-                logger.AttemptingToReserveCheckpoint(instance);
-
-                var checkpoint = await database.Execute(
-                    new ReserveNextAvailableCheckpoint(
-                        options.Subscriptions.GroupName,
-                        options.Subscriptions.ReservationTimeout,
-                        options.Postgres
-                    ),
-                    cancellationToken
-                );
-
-                if (checkpoint == null)
-                {
-                    logger.NoAvailableCheckpoints(instance);
-
-                    continue;
-                }
-
-                if (!checkpoint.IsRetryOrFailure && checkpoint.StreamPosition >= checkpoint.StreamVersion)
-                {
-                    logger.CheckpointAlreadyCaughtUp(checkpoint.Id, checkpoint.StreamPosition, instance);
-
-                    await database.Execute(
-                        new ReleaseCheckpointReservation(checkpoint.Id, options.Postgres),
+                    var checkpoint = await database.Execute(
+                        new ReserveNextAvailableCheckpoint(
+                            options.Subscriptions.GroupName,
+                            options.Subscriptions.ReservationTimeout,
+                            options.Postgres
+                        ),
                         cancellationToken
                     );
 
-                    continue;
+                    if (checkpoint == null)
+                    {
+                        logger.NoAvailableCheckpoints(consumer);
+
+                        continue;
+                    }
+
+                    if (!checkpoint.IsRetryOrFailure && checkpoint.StreamPosition >= checkpoint.StreamVersion)
+                    {
+                        logger.CheckpointAlreadyCaughtUp(checkpoint.Id, checkpoint.StreamPosition, consumer);
+
+                        await database.Execute(
+                            new ReleaseCheckpointReservation(checkpoint.Id, options.Postgres),
+                            cancellationToken
+                        );
+
+                        continue;
+                    }
+
+                    var subscription = SubscriptionRegistry.GetSubscription(checkpoint.Name);
+
+                    if (subscription == null)
+                    {
+                        logger.SubscriptionNotRegistered(
+                            checkpoint.Name,
+                            options.Subscriptions.GroupName,
+                            checkpoint.Id,
+                            consumer
+                        );
+
+                        continue;
+                    }
+
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    await checkpointProcessor.Process(
+                        consumer,
+                        checkpoint,
+                        subscription,
+                        cancellationToken
+                    );
+
+                    channel.Writer.TryWrite(CheckpointAvailable.Instance);
                 }
-
-                var subscription = SubscriptionRegistry.GetSubscription(checkpoint.Name);
-
-                if (subscription == null)
+                catch (OperationCanceledException e) when (e.CancellationToken.IsCancellationRequested)
                 {
-                    logger.SubscriptionNotRegistered(checkpoint.Name, options.Subscriptions.GroupName, checkpoint.Id, instance);
-
-                    continue;
+                    throw;
                 }
+                catch (Exception e)
+                {
+                    logger.LogError(e, "Error processing checkpoint [Consumer: {Consumer}]", consumer);
 
-                cancellationToken.ThrowIfCancellationRequested();
-
-                await checkpointProcessor.Process(
-                    instance,
-                    checkpoint,
-                    subscription,
-                    cancellationToken
-                );
-
-                channel.Writer.TryWrite(CheckpointAvailable.Instance);
-            }
-            catch (OperationCanceledException e) when (e.CancellationToken.IsCancellationRequested)
-            {
-                throw;
-            }
-            catch (Exception e)
-            {
-                logger.LogError(e, "Error processing checkpoint [Consumer: {Consumer}]", instance);
+                    channel.Writer.TryWrite(CheckpointAvailable.Instance);
+                }
             }
         }
     }
@@ -102,9 +107,28 @@ public static partial class Log
     [LoggerMessage(0, LogLevel.Trace, "No available checkpoints - will continue to wait for consumer {Consumer}")]
     public static partial void NoAvailableCheckpoints(this ILogger logger, int consumer);
 
-    [LoggerMessage(0, LogLevel.Trace, "Skipping checkpoint {CheckpointId} - already caught up at stream position {StreamPosition} - releasing reservation and continuing polling in consumer {Consumer}")]
-    public static partial void CheckpointAlreadyCaughtUp(this ILogger logger, long checkpointId, long streamPosition, int consumer);
+    [LoggerMessage(
+        0,
+        LogLevel.Trace,
+        "Skipping checkpoint {CheckpointId} - already caught up at stream position {StreamPosition} - releasing reservation and continuing polling in consumer {Consumer}"
+    )]
+    public static partial void CheckpointAlreadyCaughtUp(
+        this ILogger logger,
+        long checkpointId,
+        long streamPosition,
+        int consumer
+    );
 
-    [LoggerMessage(0, LogLevel.Trace, "Subscription {SubscriptionName} not registered for group {GroupName} - skipping checkpoint {CheckpointId} in consumer {Consumer}")]
-    public static partial void SubscriptionNotRegistered(this ILogger logger, string subscriptionName, string groupName, long checkpointId, int consumer);
+    [LoggerMessage(
+        0,
+        LogLevel.Trace,
+        "Subscription {SubscriptionName} not registered for group {GroupName} - skipping checkpoint {CheckpointId} in consumer {Consumer}"
+    )]
+    public static partial void SubscriptionNotRegistered(
+        this ILogger logger,
+        string subscriptionName,
+        string groupName,
+        long checkpointId,
+        int consumer
+    );
 }


### PR DESCRIPTION
- update polling loop to continue reading while items are available
- enqueue item when there is an unhandled exception to ensure it keeps processing
- use `Task.Run` for each consumer task as opposed to an ephemeral task
- complete the channel writer when the host is stopping to ensure a clean shutdown
- also including update for manual reservation release
  - edge case: checkpoint is reserved but is already up to date (one scenario is an overlapping reservation situation - reservation times out, new reservation started, but previous task works it to completion) ensure that the `process_at` column is also set to `NULL` so that it's not picked up again