### PR TITLE
Subscription initialization - handle unknown uninitialized subscriptions during startup

### DIFF
--- a/db/migrations/001.sql
+++ b/db/migrations/001.sql
@@ -361,7 +361,8 @@ CREATE TYPE __schema__.retry AS
 CREATE TYPE __schema__.subscription_status AS ENUM (
   'uninitialized',
   'active',
-  'paused'
+  'paused',
+  'unknown'
 );
 
 CREATE TYPE __schema__.checkpoint_status AS ENUM (
@@ -520,6 +521,21 @@ AND stream_name = '$initializing';
 
 UPDATE __schema__.subscriptions
 SET status = 'active'
+WHERE group_name = _group_name
+AND name = _name;
+$$;
+
+CREATE OR REPLACE FUNCTION __schema__.set_subscription_status(
+  _group_name text,
+  _name text,
+  _status __schema__.subscription_status
+)
+  RETURNS void
+  LANGUAGE sql
+AS
+$$
+UPDATE __schema__.subscriptions
+SET status = _status
 WHERE group_name = _group_name
 AND name = _name;
 $$;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -91,7 +91,8 @@ CREATE TYPE beckett.scheduled_message AS (
 CREATE TYPE beckett.subscription_status AS ENUM (
     'uninitialized',
     'active',
-    'paused'
+    'paused',
+    'unknown'
 );
 
 
@@ -673,6 +674,20 @@ VALUES (
   _scheduled_message.deliver_at
 )
 ON CONFLICT (id) DO NOTHING;
+$$;
+
+
+--
+-- Name: set_subscription_status(text, text, beckett.subscription_status); Type: FUNCTION; Schema: beckett; Owner: -
+--
+
+CREATE FUNCTION beckett.set_subscription_status(_group_name text, _name text, _status beckett.subscription_status) RETURNS void
+    LANGUAGE sql
+    AS $$
+UPDATE beckett.subscriptions
+SET status = _status
+WHERE group_name = _group_name
+AND name = _name;
 $$;
 
 

--- a/db/versions/0.16.10.sql
+++ b/db/versions/0.16.10.sql
@@ -1,0 +1,15 @@
+-- ensure process_at is set to NULL when releasing a checkpoint reservation
+CREATE OR REPLACE FUNCTION beckett.release_checkpoint_reservation(
+  _id bigint
+)
+  RETURNS void
+  LANGUAGE plpgsql
+AS
+$$
+BEGIN
+  UPDATE beckett.checkpoints
+  SET process_at = NULL,
+      reserved_until = NULL
+  WHERE id = _id;
+END;
+$$;

--- a/db/versions/0.16.11.sql
+++ b/db/versions/0.16.11.sql
@@ -1,0 +1,17 @@
+-- add 'unknown' subscription status and function to set status
+ALTER TYPE beckett.subscription_status ADD VALUE 'unknown';
+
+CREATE OR REPLACE FUNCTION beckett.set_subscription_status(
+  _group_name text,
+  _name text,
+  _status beckett.subscription_status
+)
+  RETURNS void
+  LANGUAGE sql
+AS
+$$
+UPDATE beckett.subscriptions
+SET status = _status
+WHERE group_name = _group_name
+AND name = _name;
+$$;

--- a/src/Beckett/Subscriptions/Initialization/SubscriptionInitializer.cs
+++ b/src/Beckett/Subscriptions/Initialization/SubscriptionInitializer.cs
@@ -33,6 +33,18 @@ public class SubscriptionInitializer(
 
             if (subscription == null)
             {
+                logger.LogWarning("Subscription {SubscriptionName} does not exist - setting status to 'unknown'", subscriptionName);
+
+                await database.Execute(
+                    new SetSubscriptionStatus(
+                        options.Subscriptions.GroupName,
+                        subscriptionName,
+                        SubscriptionStatus.Unknown,
+                        options.Postgres
+                    ),
+                    cancellationToken
+                );
+
                 continue;
             }
 

--- a/src/Beckett/Subscriptions/Initialization/SubscriptionInitializer.cs
+++ b/src/Beckett/Subscriptions/Initialization/SubscriptionInitializer.cs
@@ -33,7 +33,7 @@ public class SubscriptionInitializer(
 
             if (subscription == null)
             {
-                logger.LogWarning("Subscription {SubscriptionName} does not exist - setting status to 'unknown'", subscriptionName);
+                logger.LogWarning("Uninitialized subscription {SubscriptionName} does not exist - setting status to 'unknown'", subscriptionName);
 
                 await database.Execute(
                     new SetSubscriptionStatus(

--- a/src/Beckett/Subscriptions/Queries/SetSubscriptionStatus.cs
+++ b/src/Beckett/Subscriptions/Queries/SetSubscriptionStatus.cs
@@ -1,0 +1,34 @@
+using Beckett.Database;
+using Beckett.Database.Types;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace Beckett.Subscriptions.Queries;
+
+public class SetSubscriptionStatus(
+    string groupName,
+    string name,
+    SubscriptionStatus status,
+    PostgresOptions options
+) : IPostgresDatabaseQuery<int>
+{
+    public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
+    {
+        command.CommandText = $"select {options.Schema}.set_subscription_status($1, $2, $3);";
+
+        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
+        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
+        command.Parameters.Add(new NpgsqlParameter { DataTypeName = DataTypeNames.SubscriptionStatus(options.Schema) });
+
+        if (options.PrepareStatements)
+        {
+            await command.PrepareAsync(cancellationToken);
+        }
+
+        command.Parameters[0].Value = groupName;
+        command.Parameters[1].Value = name;
+        command.Parameters[2].Value = status;
+
+        return await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+}

--- a/src/Beckett/Subscriptions/SubscriptionStatus.cs
+++ b/src/Beckett/Subscriptions/SubscriptionStatus.cs
@@ -2,6 +2,7 @@ namespace Beckett.Subscriptions;
 
 public enum SubscriptionStatus
 {
+    Unknown,
     Uninitialized,
     Active,
     Paused


### PR DESCRIPTION
Edge case that came up - if you wind up with an uninitialized subscription that is also no longer in the subscription registry (i.e. added, didn't finish initializing, code removed, redeployed) then the subscription initializer will run in a continuous loop reading the next uninitialized subscription, seeing it doesn't exist, exiting loop, start over. This change will log a warning and set the subscription status to `unknown` in this case, so with multiple initializer tasks running you might see the same warning message logged for each (locking doesn't occur until later in the process, so each task could read the same record) but after one pass it'll be set to `unknown` and ignored from that point forward.