### PR TITLE
Checkpoint Consumer - Polling Loop Error Handling Update

### DIFF
--- a/src/Beckett/Subscriptions/CheckpointConsumer.cs
+++ b/src/Beckett/Subscriptions/CheckpointConsumer.cs
@@ -88,8 +88,6 @@ public class CheckpointConsumer(
                 catch (Exception e)
                 {
                     logger.LogError(e, "Error processing checkpoint [Consumer: {Consumer}]", consumer);
-
-                    channel.Writer.TryWrite(CheckpointAvailable.Instance);
                 }
             }
         }


### PR DESCRIPTION
Remove channel write when an exception occurs that was added in #39 - during testing it was found that if the database connection goes down temporarily this will cause an endless loop. The original thinking was that if there is an error you want the polling loop to continue, however given these findings it's best to log the error and wait for the next checkpoint update to  wake the polling loop up again.