### PR TITLE
Subscription, checkpoint, and projection updates

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,6 +15,7 @@
     <PackageVersion Include="Npgsql" Version="9.0.2" />
     <PackageVersion Include="Npgsql.DependencyInjection" Version="9.0.2" />
     <PackageVersion Include="Npgsql.OpenTelemetry" Version="9.0.2" />
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="OpenTelemetry" Version="1.10.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.10.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />

--- a/db/migrations/001.sql
+++ b/db/migrations/001.sql
@@ -423,7 +423,7 @@ BEGIN
     NEW.process_at = now();
   END IF;
 
-  IF (NEW.name != '$global' AND NEW.process_at IS NOT NULL) THEN
+  IF (NEW.name != '$global' AND NEW.process_at IS NOT NULL AND NEW.reserved_until IS NULL) THEN
     PERFORM pg_notify('beckett:checkpoints', NEW.group_name);
   END IF;
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -220,7 +220,7 @@ BEGIN
     NEW.process_at = now();
   END IF;
 
-  IF (NEW.name != '$global' AND NEW.process_at IS NOT NULL) THEN
+  IF (NEW.name != '$global' AND NEW.process_at IS NOT NULL AND NEW.reserved_until IS NULL) THEN
     PERFORM pg_notify('beckett:checkpoints', NEW.group_name);
   END IF;
 

--- a/db/versions/0.16.13.sql
+++ b/db/versions/0.16.13.sql
@@ -1,0 +1,22 @@
+-- update checkpoint preprocessor - do not trigger notifications when checkpoints are reserved
+CREATE OR REPLACE FUNCTION beckett.checkpoint_preprocessor()
+  RETURNS trigger
+  LANGUAGE plpgsql
+AS
+$$
+BEGIN
+  IF (TG_OP = 'UPDATE') THEN
+    NEW.updated_at = now();
+  END IF;
+
+  IF (NEW.status = 'active' AND NEW.process_at IS NULL AND NEW.stream_version > NEW.stream_position) THEN
+    NEW.process_at = now();
+  END IF;
+
+  IF (NEW.name != '$global' AND NEW.process_at IS NOT NULL AND NEW.reserved_until IS NULL) THEN
+    PERFORM pg_notify('beckett:checkpoints', NEW.group_name);
+  END IF;
+
+  RETURN NEW;
+END;
+$$;

--- a/src/Beckett.Tests/Beckett.Tests.csproj
+++ b/src/Beckett.Tests/Beckett.Tests.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+    <PackageReference Include="NSubstitute" />
     <PackageReference Include="xunit"/>
     <PackageReference Include="xunit.runner.visualstudio"/>
   </ItemGroup>

--- a/src/Beckett.Tests/GlobalTestSetup.cs
+++ b/src/Beckett.Tests/GlobalTestSetup.cs
@@ -1,0 +1,9 @@
+using System.Runtime.CompilerServices;
+
+namespace Beckett.Tests;
+
+public static class GlobalTestSetup
+{
+    [ModuleInitializer]
+    internal static void Initialize() => MessageRegistry.Register();
+}

--- a/src/Beckett.Tests/MessageStorage/InMemory/InMemoryMessageStorageTests.cs
+++ b/src/Beckett.Tests/MessageStorage/InMemory/InMemoryMessageStorageTests.cs
@@ -4,14 +4,8 @@ using Beckett.MessageStorage.InMemory;
 
 namespace Beckett.Tests.MessageStorage.InMemory;
 
-[Collection("MessageTypeMap")]
-public class InMemoryMessageStorageTests : IDisposable
+public class InMemoryMessageStorageTests
 {
-    public InMemoryMessageStorageTests()
-    {
-        MessageTypeMap.Map<TestEvent>("test_event");
-    }
-
     [Fact]
     public async Task appends_to_and_reads_stream()
     {
@@ -49,13 +43,6 @@ public class InMemoryMessageStorageTests : IDisposable
         Assert.Equal(1, item.GlobalPosition);
         Assert.Equal(1, item.StreamPosition);
         Assert.Equal(streamName, item.StreamName);
-        Assert.Equal("test_event", item.MessageType);
-    }
-
-    public record TestEvent(int Number);
-
-    public void Dispose()
-    {
-        MessageTypeMap.Clear();
+        Assert.Equal("test-event", item.MessageType);
     }
 }

--- a/src/Beckett.Tests/MessageTests.cs
+++ b/src/Beckett.Tests/MessageTests.cs
@@ -1,16 +1,9 @@
 using System.Text.Json;
-using Beckett.Messages;
 
 namespace Beckett.Tests;
 
-[Collection("MessageTypeMap")]
-public sealed class MessageTests : IDisposable
+public class MessageTests
 {
-    public MessageTests()
-    {
-        MessageTypeMap.Map<TestMessage>("test-message");
-    }
-
     [Fact]
     public void maps_type_and_serializes_data_in_constructor()
     {
@@ -71,12 +64,5 @@ public sealed class MessageTests : IDisposable
         message.WithTenant(expectedTenant);
 
         Assert.Single(message.Metadata, new KeyValuePair<string, string>("$tenant", expectedTenant));
-    }
-
-    private record TestMessage(Guid Id);
-
-    public void Dispose()
-    {
-        MessageTypeMap.Clear();
     }
 }

--- a/src/Beckett.Tests/MessageTypes.cs
+++ b/src/Beckett.Tests/MessageTypes.cs
@@ -1,0 +1,19 @@
+using Beckett.Messages;
+
+namespace Beckett.Tests;
+
+public record TestMessage(Guid Id);
+
+public record AnotherTestMessage(Guid Id);
+
+public record TestEvent(int Number);
+
+public static class MessageRegistry
+{
+    public static void Register()
+    {
+        MessageTypeMap.Map<TestMessage>("test-message");
+        MessageTypeMap.Map<AnotherTestMessage>("another-test-message");
+        MessageTypeMap.Map<TestEvent>("test-event");
+    }
+}

--- a/src/Beckett.Tests/Messages/MessageTypeMapTests.cs
+++ b/src/Beckett.Tests/Messages/MessageTypeMapTests.cs
@@ -3,9 +3,8 @@ using Beckett.Messages;
 
 namespace Beckett.Tests.Messages;
 
-[Collection("MessageTypeMap")]
 [SuppressMessage("ReSharper", "ClassNeverInstantiated.Local")]
-public sealed class MessageTypeMapTests : IDisposable
+public class MessageTypeMapTests
 {
     [Fact]
     public void maps_type_name()
@@ -36,11 +35,6 @@ public sealed class MessageTypeMapTests : IDisposable
         Assert.Throws<MessageTypeAlreadyMappedException>(
             () => MessageTypeMap.Map<TestMessage2>("type-map-test")
         );
-    }
-
-    public void Dispose()
-    {
-        MessageTypeMap.Clear();
     }
 
     private record TestMessage;

--- a/src/Beckett.Tests/Projections/ProjectionConfigurationTests.cs
+++ b/src/Beckett.Tests/Projections/ProjectionConfigurationTests.cs
@@ -58,26 +58,10 @@ public partial class ProjectionConfigurationTests
         }
     }
 
-    public class when_ignore_filter_is_configured
+    public class when_where_predicate_is_configured
     {
         [Fact]
-        public void excludes_messages_matching_filter()
-        {
-            var projection = new TestReadModelProjection();
-            var configuration = new ProjectionConfiguration<Guid>();
-            projection.Configure(configuration);
-            var batch = new List<IMessageContext>
-            {
-                MessageContext.From(new TestCreateMessage(Guid.Empty))
-            };
-
-            var filteredBatch = configuration.Filter(batch);
-
-            Assert.Empty(filteredBatch);
-        }
-
-        [Fact]
-        public void includes_messages_that_do_not_match_filter()
+        public void includes_messages_matching_predicate()
         {
             var projection = new TestReadModelProjection();
             var configuration = new ProjectionConfiguration<Guid>();
@@ -90,6 +74,22 @@ public partial class ProjectionConfigurationTests
             var filteredBatch = configuration.Filter(batch);
 
             Assert.Single(filteredBatch);
+        }
+
+        [Fact]
+        public void excludes_messages_that_do_not_match_predicate()
+        {
+            var projection = new TestReadModelProjection();
+            var configuration = new ProjectionConfiguration<Guid>();
+            projection.Configure(configuration);
+            var batch = new List<IMessageContext>
+            {
+                MessageContext.From(new TestCreateMessage(Guid.Empty))
+            };
+
+            var filteredBatch = configuration.Filter(batch);
+
+            Assert.Empty(filteredBatch);
         }
     }
 
@@ -109,7 +109,7 @@ public partial class ProjectionConfigurationTests
     {
         public void Configure(IProjectionConfiguration<Guid> configuration)
         {
-            configuration.CreatedBy<TestCreateMessage>(x => x.Id).IgnoreWhen(x => x.Id == Guid.Empty);
+            configuration.CreatedBy<TestCreateMessage>(x => x.Id).Where(x => x.Id != Guid.Empty);
             configuration.UpdatedBy<TestUpdateMessage>(x => x.Id);
         }
 

--- a/src/Beckett.Tests/Subscriptions/CheckpointProcessorTests.cs
+++ b/src/Beckett.Tests/Subscriptions/CheckpointProcessorTests.cs
@@ -1,0 +1,205 @@
+using Beckett.Database;
+using Beckett.Messages;
+using Beckett.OpenTelemetry;
+using Beckett.Subscriptions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Beckett.Tests.Subscriptions;
+
+public class CheckpointProcessorTests
+{
+    public class when_checkpoint_is_active
+    {
+        public class when_messages_to_process_is_less_than_batch_size : IClassFixture<MessageTypes>
+        {
+            [Fact]
+            public async Task only_reads_messages_up_to_stream_version()
+            {
+                var checkpoint = new Checkpoint(1, "test", "test", "test", 0, 10, 0, CheckpointStatus.Active);
+                var subscription = new Subscription("test")
+                {
+                    HandlerDelegate = (IMessageContext _) => { }
+                };
+                subscription.RegisterMessageType<TestMessage>();
+                subscription.BuildHandler();
+                var options = new BeckettOptions
+                {
+                    Subscriptions =
+                    {
+                        SubscriptionStreamBatchSize = 10
+                    }
+                };
+                var messageStore = Substitute.For<IMessageStore>();
+                var checkpointProcessor = BuildCheckpointProcessor(options, messageStore);
+
+                await checkpointProcessor.Process(1, checkpoint, subscription, CancellationToken.None);
+
+                await messageStore.Received().ReadStream(
+                    "test",
+                    Arg.Is<ReadOptions>(x => x.StartingStreamPosition == 1 && x.EndingStreamPosition == 10),
+                    CancellationToken.None
+                );
+            }
+        }
+
+        public class when_messages_to_process_exceeds_batch_size : IClassFixture<MessageTypes>
+        {
+            [Fact]
+            public async Task only_reads_messages_up_to_batch_size()
+            {
+                var checkpoint = new Checkpoint(1, "test", "test", "test", 0, 20, 0, CheckpointStatus.Active);
+                var subscription = new Subscription("test")
+                {
+                    HandlerDelegate = (IMessageContext _) => { }
+                };
+                subscription.RegisterMessageType<TestMessage>();
+                subscription.BuildHandler();
+                var options = new BeckettOptions
+                {
+                    Subscriptions =
+                    {
+                        SubscriptionStreamBatchSize = 10
+                    }
+                };
+                var messageStore = Substitute.For<IMessageStore>();
+                var checkpointProcessor = BuildCheckpointProcessor(options, messageStore);
+
+                await checkpointProcessor.Process(1, checkpoint, subscription, CancellationToken.None);
+
+                await messageStore.Received().ReadStream(
+                    "test",
+                    Arg.Is<ReadOptions>(x => x.StartingStreamPosition == 1 && x.EndingStreamPosition == 10),
+                    CancellationToken.None
+                );
+            }
+        }
+    }
+
+    public class when_checkpoint_is_retry_or_failure
+    {
+        public class when_subscription_handler_is_batch_handler
+        {
+            public class when_messages_to_process_is_less_than_batch_size : IClassFixture<MessageTypes>
+            {
+                [Fact]
+                public async Task only_reads_messages_up_to_stream_version()
+                {
+                    var checkpoint = new Checkpoint(1, "test", "test", "test", 1, 10, 0, CheckpointStatus.Retry);
+                    var subscription = new Subscription("test")
+                    {
+                        HandlerDelegate = (IReadOnlyList<IMessageContext> _) => { }
+                    };
+                    subscription.RegisterMessageType<TestMessage>();
+                    subscription.BuildHandler();
+                    var options = new BeckettOptions
+                    {
+                        Subscriptions =
+                        {
+                            SubscriptionStreamBatchSize = 10
+                        }
+                    };
+                    var messageStore = Substitute.For<IMessageStore>();
+                    var checkpointProcessor = BuildCheckpointProcessor(options, messageStore);
+
+                    await checkpointProcessor.Process(1, checkpoint, subscription, CancellationToken.None);
+
+                    await messageStore.Received().ReadStream(
+                        "test",
+                        Arg.Is<ReadOptions>(x => x.StartingStreamPosition == 1 && x.EndingStreamPosition == 10),
+                        CancellationToken.None
+                    );
+                }
+            }
+
+            public class when_messages_to_process_exceeds_batch_size : IClassFixture<MessageTypes>
+            {
+                [Fact]
+                public async Task only_reads_messages_up_to_batch_size()
+                {
+                    var checkpoint = new Checkpoint(1, "test", "test", "test", 1, 20, 0, CheckpointStatus.Retry);
+                    var subscription = new Subscription("test")
+                    {
+                        HandlerDelegate = (IReadOnlyList<IMessageContext> _) => { }
+                    };
+                    subscription.RegisterMessageType<TestMessage>();
+                    subscription.BuildHandler();
+                    var options = new BeckettOptions
+                    {
+                        Subscriptions =
+                        {
+                            SubscriptionStreamBatchSize = 10
+                        }
+                    };
+                    var messageStore = Substitute.For<IMessageStore>();
+                    var checkpointProcessor = BuildCheckpointProcessor(options, messageStore);
+
+                    await checkpointProcessor.Process(1, checkpoint, subscription, CancellationToken.None);
+
+                    await messageStore.Received().ReadStream(
+                        "test",
+                        Arg.Is<ReadOptions>(x => x.StartingStreamPosition == 1 && x.EndingStreamPosition == 11),
+                        CancellationToken.None
+                    );
+                }
+            }
+        }
+
+        public class when_subscription_handler_is_not_batch_handler : IClassFixture<MessageTypes>
+        {
+            [Fact]
+            public async Task only_reads_one_message_to_retry()
+            {
+                var checkpoint = new Checkpoint(1, "test", "test", "test", 1, 20, 0, CheckpointStatus.Retry);
+                var subscription = new Subscription("test")
+                {
+                    HandlerDelegate = (IMessageContext _) => { }
+                };
+                subscription.RegisterMessageType<TestMessage>();
+                subscription.BuildHandler();
+                var options = new BeckettOptions
+                {
+                    Subscriptions =
+                    {
+                        SubscriptionStreamBatchSize = 10
+                    }
+                };
+                var messageStore = Substitute.For<IMessageStore>();
+                var checkpointProcessor = BuildCheckpointProcessor(options, messageStore);
+
+                await checkpointProcessor.Process(1, checkpoint, subscription, CancellationToken.None);
+
+                await messageStore.Received().ReadStream(
+                    "test",
+                    Arg.Is<ReadOptions>(x => x.StartingStreamPosition == 1 && x.EndingStreamPosition == 2),
+                    CancellationToken.None
+                );
+            }
+        }
+    }
+
+    private static CheckpointProcessor BuildCheckpointProcessor(BeckettOptions options, IMessageStore messageStore)
+    {
+        var database = Substitute.For<IPostgresDatabase>();
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        var instrumentation = Substitute.For<IInstrumentation>();
+        var logger = Substitute.For<ILogger<CheckpointProcessor>>();
+
+        return new CheckpointProcessor(messageStore, database, serviceProvider, options, instrumentation, logger);
+    }
+
+    public record TestMessage;
+
+    public class MessageTypes : IDisposable
+    {
+        public MessageTypes()
+        {
+            MessageTypeMap.Map<TestMessage>("test_message");
+        }
+
+        public void Dispose()
+        {
+            MessageTypeMap.Clear();
+        }
+    }
+}

--- a/src/Beckett.Tests/Subscriptions/SubscriptionHandlerTests.cs
+++ b/src/Beckett.Tests/Subscriptions/SubscriptionHandlerTests.cs
@@ -5,8 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Beckett.Tests.Subscriptions;
 
-[Collection("MessageTypeMap")]
-public class SubscriptionHandlerTests : IDisposable
+public class SubscriptionHandlerTests
 {
     private readonly Subscription _subscription = new("test");
     private readonly IServiceProvider _serviceProvider;
@@ -14,9 +13,6 @@ public class SubscriptionHandlerTests : IDisposable
 
     public SubscriptionHandlerTests()
     {
-        MessageTypeMap.Map<TestMessage>("test-message");
-        MessageTypeMap.Map<AnotherTestMessage>("another-test-message");
-
         _serviceProvider = new ServiceCollection()
             .AddSingleton(_testService)
             .BuildServiceProvider();
@@ -395,14 +391,5 @@ public class SubscriptionHandlerTests : IDisposable
 
             return Task.CompletedTask;
         }
-    }
-
-    private record TestMessage(Guid Id);
-
-    private record AnotherTestMessage(Guid Id);
-
-    public void Dispose()
-    {
-        MessageTypeMap.Clear();
     }
 }

--- a/src/Beckett.Tests/Subscriptions/SubscriptionHandlerTests.cs
+++ b/src/Beckett.Tests/Subscriptions/SubscriptionHandlerTests.cs
@@ -148,6 +148,21 @@ public class SubscriptionHandlerTests : IDisposable
     }
 
     [Fact]
+    public void handlers_can_return_void()
+    {
+        _subscription.RegisterMessageType<TestMessage>();
+
+        try
+        {
+            _ = new SubscriptionHandler(_subscription, HandlerThatReturnsVoid.Handle);
+        }
+        catch
+        {
+            Assert.Fail("Handlers should be able to return void");
+        }
+    }
+
+    [Fact]
     public void handlers_must_subscribe_to_at_least_one_message_type_if_category_not_specified()
     {
         Assert.Throws<InvalidOperationException>(
@@ -193,10 +208,10 @@ public class SubscriptionHandlerTests : IDisposable
     }
 
     [Fact]
-    public void handlers_must_return_task()
+    public void handlers_must_return_task_or_void_only()
     {
         Assert.Throws<InvalidOperationException>(
-            () => new SubscriptionHandler(_subscription, InvalidHandlerThatReturnsVoid.Handle)
+            () => new SubscriptionHandler(_subscription, InvalidHandlerThatReturnsNonTaskOrVoid.Handle)
         );
     }
 
@@ -327,6 +342,13 @@ public class SubscriptionHandlerTests : IDisposable
         }
     }
 
+    private static class HandlerThatReturnsVoid
+    {
+        public static void Handle(IMessageContext context)
+        {
+        }
+    }
+
     private static class InvalidHandlerWithContextAndBatch
     {
         public static Task Handle(IMessageContext context, IReadOnlyList<IMessageContext> batch, CancellationToken cancellationToken)
@@ -351,11 +373,9 @@ public class SubscriptionHandlerTests : IDisposable
         }
     }
 
-    private static class InvalidHandlerThatReturnsVoid
+    private static class InvalidHandlerThatReturnsNonTaskOrVoid
     {
-        public static void Handle(IMessageContext context)
-        {
-        }
+        public static int Handle(IMessageContext context) => 1;
     }
 
     private interface ITestService

--- a/src/Beckett.Tests/packages.lock.json
+++ b/src/Beckett.Tests/packages.lock.json
@@ -18,6 +18,15 @@
           "Microsoft.TestPlatform.TestHost": "17.12.0"
         }
       },
+      "NSubstitute": {
+        "type": "Direct",
+        "requested": "[5.3.0, )",
+        "resolved": "5.3.0",
+        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
+        "dependencies": {
+          "Castle.Core": "5.1.1"
+        }
+      },
       "xunit": {
         "type": "Direct",
         "requested": "[2.9.3, )",
@@ -34,6 +43,14 @@
         "requested": "[3.0.1, )",
         "resolved": "3.0.1",
         "contentHash": "lbyYtsBxA8Pz8kaf5Xn/Mj1mL9z2nlBWdZhqFaj66nxXBa4JwiTDm4eGcpSMet6du9TOWI6bfha+gQR6+IHawg=="
+      },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "6.0.0"
+        }
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
@@ -197,6 +214,11 @@
         "type": "Transitive",
         "resolved": "9.0.0",
         "contentHash": "ddppcFpnbohLWdYKr/ZeLZHmmI+DXFgZ3Snq+/E7SwcdW4UnvxmaugkwGywvGVWkHPGCSZjCP+MLzu23AL5SDw=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",

--- a/src/Beckett/Projections/IProjectionConfiguration.cs
+++ b/src/Beckett/Projections/IProjectionConfiguration.cs
@@ -85,7 +85,7 @@ public class ProjectionConfiguration<TKey> : IProjectionConfiguration<TKey>
     public IReadOnlyList<IMessageContext> Filter(IReadOnlyList<IMessageContext> batch)
     {
         return batch.Where(x => x.MessageType != null && _map.ContainsKey(x.MessageType))
-            .Where(x => !_map[x.MessageType!].IgnoreFilter(x.Message!)).ToList();
+            .Where(x => _map[x.MessageType!].WherePredicate(x.Message!)).ToList();
     }
 
     public TKey GetKey(IMessageContext context) =>

--- a/src/Beckett/Projections/IProjectionMessageConfiguration.cs
+++ b/src/Beckett/Projections/IProjectionMessageConfiguration.cs
@@ -3,7 +3,7 @@ namespace Beckett.Projections;
 public interface IProjectionMessageConfiguration<out TMessage, TKey>
 {
     IProjectionMessageConfiguration<TMessage, TKey> IgnoreWhenNotFound();
-    IProjectionMessageConfiguration<TMessage, TKey> IgnoreWhen(Predicate<TMessage> predicate);
+    IProjectionMessageConfiguration<TMessage, TKey> Where(Predicate<TMessage> predicate);
 }
 
 public class ProjectionMessageConfiguration<TMessage, TKey> : IProjectionMessageConfiguration<TMessage, TKey>
@@ -34,9 +34,9 @@ public class ProjectionMessageConfiguration<TMessage, TKey> : IProjectionMessage
         return this;
     }
 
-    public IProjectionMessageConfiguration<TMessage, TKey> IgnoreWhen(Predicate<TMessage> predicate)
+    public IProjectionMessageConfiguration<TMessage, TKey> Where(Predicate<TMessage> predicate)
     {
-        Configuration.IgnoreFilter = x => predicate((TMessage)x);
+        Configuration.WherePredicate = x => predicate((TMessage)x);
 
         return this;
     }
@@ -47,7 +47,7 @@ public class ProjectionMessageConfiguration
     internal ProjectionAction Action { get; set; }
     internal Func<object, object> Key { get; set; } = null!;
     internal bool IgnoreWhenNotFound { get; set; }
-    internal Predicate<object> IgnoreFilter { get; set; } = _ => false;
+    internal Predicate<object> WherePredicate { get; set; } = _ => true;
 
     internal TKey GetKey<TKey>(object message) => (TKey)Key(message);
 }

--- a/src/Beckett/Subscriptions/Checkpoint.cs
+++ b/src/Beckett/Subscriptions/Checkpoint.cs
@@ -15,6 +15,8 @@ public record Checkpoint(
 {
     public bool IsRetryOrFailure => Status is CheckpointStatus.Retry or CheckpointStatus.Failed;
 
+    public long StartingStreamPosition => StreamPosition + 1;
+
     public static Checkpoint? From(NpgsqlDataReader reader)
     {
         return !reader.HasRows


### PR DESCRIPTION
- projections - rename `IgnoreWhen` to `Where` to make it clear what it does
- subscription handlers - support handlers that return `void` in addition to `Task`
- checkpoint processor - only process messages that need to be processed
- checkpoint preprocessor trigger - reduce checkpoint notification load