### PR TITLE
Checkpoint cancellation handling

### DIFF
--- a/samples/TaskHub/TaskHub/TaskLists/TaskListModule.cs
+++ b/samples/TaskHub/TaskHub/TaskLists/TaskListModule.cs
@@ -47,9 +47,9 @@ public class TaskListModule : IModule, IConfigureRoutes
             .Handler(
                 (IMessageContext context) =>
                 {
-                    Console.WriteLine($"[MESSAGE] category: {Category}, stream: {context.StreamName}, type: {context.Type}, id: {context.Id} [lag: {DateTimeOffset.UtcNow.Subtract(context.Timestamp).TotalMilliseconds} ms]");
-
-                    return Task.CompletedTask;
+                    Console.WriteLine(
+                        $"[MESSAGE] category: {Category}, stream: {context.StreamName}, type: {context.Type}, id: {context.Id} [lag: {DateTimeOffset.UtcNow.Subtract(context.Timestamp).TotalMilliseconds} ms]"
+                    );
                 }
             );
     }

--- a/samples/TaskHub/TaskHub/Users/UserModule.cs
+++ b/samples/TaskHub/TaskHub/Users/UserModule.cs
@@ -38,9 +38,9 @@ public class UserModule : IModule, IConfigureRoutes
             .Handler(
                 (IMessageContext context) =>
                 {
-                    Console.WriteLine($"[MESSAGE] category: {Category}, stream: {context.StreamName}, type: {context.Type}, id: {context.Id} [lag: {DateTimeOffset.UtcNow.Subtract(context.Timestamp).TotalMilliseconds} ms]");
-
-                    return Task.CompletedTask;
+                    Console.WriteLine(
+                        $"[MESSAGE] category: {Category}, stream: {context.StreamName}, type: {context.Type}, id: {context.Id} [lag: {DateTimeOffset.UtcNow.Subtract(context.Timestamp).TotalMilliseconds} ms]"
+                    );
                 }
             );
     }

--- a/src/Beckett.Tests/Subscriptions/CheckpointProcessorTests.cs
+++ b/src/Beckett.Tests/Subscriptions/CheckpointProcessorTests.cs
@@ -1,7 +1,10 @@
+using System.Text.Json;
 using Beckett.Database;
 using Beckett.Messages;
 using Beckett.OpenTelemetry;
 using Beckett.Subscriptions;
+using Beckett.Subscriptions.Queries;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 
@@ -11,7 +14,7 @@ public class CheckpointProcessorTests
 {
     public class when_checkpoint_is_active
     {
-        public class when_messages_to_process_is_less_than_batch_size : IClassFixture<MessageTypes>
+        public class when_messages_to_process_is_less_than_batch_size
         {
             [Fact]
             public async Task only_reads_messages_up_to_stream_version()
@@ -43,7 +46,7 @@ public class CheckpointProcessorTests
             }
         }
 
-        public class when_messages_to_process_exceeds_batch_size : IClassFixture<MessageTypes>
+        public class when_messages_to_process_exceeds_batch_size
         {
             [Fact]
             public async Task only_reads_messages_up_to_batch_size()
@@ -76,76 +79,118 @@ public class CheckpointProcessorTests
         }
     }
 
-    public class when_checkpoint_is_retry_or_failure
+    public class when_subscription_handler_is_message_handler
     {
-        public class when_subscription_handler_is_batch_handler
+        public class when_reservation_timeout_is_exceeded
         {
-            public class when_messages_to_process_is_less_than_batch_size : IClassFixture<MessageTypes>
+            [Fact]
+            public async Task throws_timeout_exception()
             {
-                [Fact]
-                public async Task only_reads_messages_up_to_stream_version()
+                var checkpoint = new Checkpoint(1, "test", "test", "test", 1, 2, 0, CheckpointStatus.Active);
+                var subscription = new Subscription("test")
                 {
-                    var checkpoint = new Checkpoint(1, "test", "test", "test", 1, 10, 0, CheckpointStatus.Retry);
-                    var subscription = new Subscription("test")
+                    HandlerDelegate = async (IMessageContext _, CancellationToken ct) =>
                     {
-                        HandlerDelegate = (IReadOnlyList<IMessageContext> _) => { }
-                    };
-                    subscription.RegisterMessageType<TestMessage>();
-                    subscription.BuildHandler();
-                    var options = new BeckettOptions
-                    {
-                        Subscriptions =
-                        {
-                            SubscriptionStreamBatchSize = 10
-                        }
-                    };
-                    var messageStore = Substitute.For<IMessageStore>();
-                    var checkpointProcessor = BuildCheckpointProcessor(options, messageStore);
-
-                    await checkpointProcessor.Process(1, checkpoint, subscription, CancellationToken.None);
-
-                    await messageStore.Received().ReadStream(
-                        "test",
-                        Arg.Is<ReadOptions>(x => x.StartingStreamPosition == 1 && x.EndingStreamPosition == 10),
-                        CancellationToken.None
-                    );
-                }
-            }
-
-            public class when_messages_to_process_exceeds_batch_size : IClassFixture<MessageTypes>
-            {
-                [Fact]
-                public async Task only_reads_messages_up_to_batch_size()
+                        await Task.Delay(TimeSpan.FromMilliseconds(2), ct);
+                    }
+                };
+                subscription.RegisterMessageType<TestMessage>();
+                subscription.BuildHandler();
+                var options = new BeckettOptions
                 {
-                    var checkpoint = new Checkpoint(1, "test", "test", "test", 1, 20, 0, CheckpointStatus.Retry);
-                    var subscription = new Subscription("test")
+                    Subscriptions =
                     {
-                        HandlerDelegate = (IReadOnlyList<IMessageContext> _) => { }
-                    };
-                    subscription.RegisterMessageType<TestMessage>();
-                    subscription.BuildHandler();
-                    var options = new BeckettOptions
-                    {
-                        Subscriptions =
-                        {
-                            SubscriptionStreamBatchSize = 10
-                        }
-                    };
-                    var messageStore = Substitute.For<IMessageStore>();
-                    var checkpointProcessor = BuildCheckpointProcessor(options, messageStore);
+                        ReservationTimeout = TimeSpan.FromMilliseconds(1)
+                    }
+                };
+                var messageStore = Substitute.For<IMessageStore>();
+                var database = Substitute.For<IPostgresDatabase>();
+                var checkpointProcessor = BuildCheckpointProcessor(options, messageStore, database);
+                messageStore.ReadStream("test", Arg.Any<ReadOptions>(), CancellationToken.None)
+                    .Returns(new MessageStream("test", 2, [BuildMessageContext()], messageStore.AppendToStream));
+                RecordCheckpointError? error = null;
+                database.WhenForAnyArgs(x => x.Execute(Arg.Any<RecordCheckpointError>(), Arg.Any<CancellationToken>()))
+                    .Do(x => error = x.Arg<RecordCheckpointError>());
 
-                    await checkpointProcessor.Process(1, checkpoint, subscription, CancellationToken.None);
+                await checkpointProcessor.Process(1, checkpoint, subscription, CancellationToken.None);
 
-                    await messageStore.Received().ReadStream(
-                        "test",
-                        Arg.Is<ReadOptions>(x => x.StartingStreamPosition == 1 && x.EndingStreamPosition == 11),
-                        CancellationToken.None
-                    );
-                }
+                Assert.NotNull(error);
+                Assert.True(IsTimeoutException(error));
             }
         }
 
-        public class when_subscription_handler_is_not_batch_handler : IClassFixture<MessageTypes>
+        public class when_nested_timeout_exception_is_thrown
+        {
+            [Fact]
+            public async Task throws_timeout_exception()
+            {
+                var checkpoint = new Checkpoint(1, "test", "test", "test", 1, 2, 0, CheckpointStatus.Active);
+                var subscription = new Subscription("test")
+                {
+                    HandlerDelegate = (IMessageContext _, CancellationToken ct) =>
+                    {
+                        throw new TaskCanceledException("test", new TimeoutException("timeout"), ct);
+                    }
+                };
+                subscription.RegisterMessageType<TestMessage>();
+                subscription.BuildHandler();
+                var options = new BeckettOptions
+                {
+                    Subscriptions =
+                    {
+                        ReservationTimeout = TimeSpan.FromMilliseconds(1)
+                    }
+                };
+                var messageStore = Substitute.For<IMessageStore>();
+                var database = Substitute.For<IPostgresDatabase>();
+                var checkpointProcessor = BuildCheckpointProcessor(options, messageStore, database);
+                messageStore.ReadStream("test", Arg.Any<ReadOptions>(), CancellationToken.None)
+                    .Returns(new MessageStream("test", 2, [BuildMessageContext()], messageStore.AppendToStream));
+                RecordCheckpointError? error = null;
+                database.WhenForAnyArgs(x => x.Execute(Arg.Any<RecordCheckpointError>(), Arg.Any<CancellationToken>()))
+                    .Do(x => error = x.Arg<RecordCheckpointError>());
+
+                await checkpointProcessor.Process(1, checkpoint, subscription, CancellationToken.None);
+
+                Assert.NotNull(error);
+                Assert.True(IsTimeoutException(error));
+            }
+        }
+
+        public class when_the_stopping_token_is_cancelled
+        {
+            [Fact]
+            public async Task throws_operation_canceled_exception()
+            {
+                var checkpoint = new Checkpoint(1, "test", "test", "test", 1, 2, 0, CheckpointStatus.Active);
+                var subscription = new Subscription("test")
+                {
+                    HandlerDelegate = (IMessageContext _, CancellationToken ct) =>
+                        Task.Delay(TimeSpan.FromMilliseconds(2), ct)
+                };
+                subscription.RegisterMessageType<TestMessage>();
+                subscription.BuildHandler();
+                var options = new BeckettOptions
+                {
+                    Subscriptions =
+                    {
+                        ReservationTimeout = TimeSpan.FromMilliseconds(1)
+                    }
+                };
+                var messageStore = Substitute.For<IMessageStore>();
+                var checkpointProcessor = BuildCheckpointProcessor(options, messageStore);
+                var parentCts = new CancellationTokenSource();
+                var innerCts = CancellationTokenSource.CreateLinkedTokenSource(parentCts.Token);
+
+                messageStore.ReadStream("test", Arg.Any<ReadOptions>(), Arg.Any<CancellationToken>())
+                    .Returns(new MessageStream("test", 2, [BuildMessageContext()], messageStore.AppendToStream));
+                await parentCts.CancelAsync();
+
+                await Assert.ThrowsAsync<OperationCanceledException>(() => checkpointProcessor.Process(1, checkpoint, subscription, innerCts.Token));
+            }
+        }
+
+        public class when_checkpoint_is_retry_or_failure
         {
             [Fact]
             public async Task only_reads_one_message_to_retry()
@@ -178,28 +223,217 @@ public class CheckpointProcessorTests
         }
     }
 
-    private static CheckpointProcessor BuildCheckpointProcessor(BeckettOptions options, IMessageStore messageStore)
+    public class when_subscription_handler_is_batch_handler
     {
-        var database = Substitute.For<IPostgresDatabase>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        public class when_reservation_timeout_is_exceeded
+        {
+            [Fact]
+            public async Task throws_timeout_exception()
+            {
+                var checkpoint = new Checkpoint(1, "test", "test", "test", 1, 2, 0, CheckpointStatus.Active);
+                var subscription = new Subscription("test")
+                {
+                    HandlerDelegate = async (IReadOnlyList<IMessageContext> _, CancellationToken ct) =>
+                    {
+                        await Task.Delay(TimeSpan.FromMilliseconds(2), ct);
+                    }
+                };
+                subscription.RegisterMessageType<TestMessage>();
+                subscription.BuildHandler();
+                var options = new BeckettOptions
+                {
+                    Subscriptions =
+                    {
+                        ReservationTimeout = TimeSpan.FromMilliseconds(1)
+                    }
+                };
+                var messageStore = Substitute.For<IMessageStore>();
+                var database = Substitute.For<IPostgresDatabase>();
+                var checkpointProcessor = BuildCheckpointProcessor(options, messageStore, database);
+                messageStore.ReadStream("test", Arg.Any<ReadOptions>(), CancellationToken.None)
+                    .Returns(new MessageStream("test", 2, [BuildMessageContext()], messageStore.AppendToStream));
+                RecordCheckpointError? error = null;
+                database.WhenForAnyArgs(x => x.Execute(Arg.Any<RecordCheckpointError>(), Arg.Any<CancellationToken>()))
+                    .Do(x => error = x.Arg<RecordCheckpointError>());
+
+                await checkpointProcessor.Process(1, checkpoint, subscription, CancellationToken.None);
+
+                Assert.NotNull(error);
+                Assert.True(IsTimeoutException(error));
+            }
+        }
+
+        public class when_nested_timeout_exception_is_thrown
+        {
+            [Fact]
+            public async Task throws_timeout_exception()
+            {
+                var checkpoint = new Checkpoint(1, "test", "test", "test", 1, 2, 0, CheckpointStatus.Active);
+                var subscription = new Subscription("test")
+                {
+                    HandlerDelegate = (IReadOnlyList<IMessageContext> _, CancellationToken ct) =>
+                    {
+                        throw new TaskCanceledException("test", new TimeoutException("timeout"), ct);
+                    }
+                };
+                subscription.RegisterMessageType<TestMessage>();
+                subscription.BuildHandler();
+                var options = new BeckettOptions
+                {
+                    Subscriptions =
+                    {
+                        ReservationTimeout = TimeSpan.FromMilliseconds(1)
+                    }
+                };
+                var messageStore = Substitute.For<IMessageStore>();
+                var database = Substitute.For<IPostgresDatabase>();
+                var checkpointProcessor = BuildCheckpointProcessor(options, messageStore, database);
+                messageStore.ReadStream("test", Arg.Any<ReadOptions>(), CancellationToken.None)
+                    .Returns(new MessageStream("test", 2, [BuildMessageContext()], messageStore.AppendToStream));
+                RecordCheckpointError? error = null;
+                database.WhenForAnyArgs(x => x.Execute(Arg.Any<RecordCheckpointError>(), Arg.Any<CancellationToken>()))
+                    .Do(x => error = x.Arg<RecordCheckpointError>());
+
+                await checkpointProcessor.Process(1, checkpoint, subscription, CancellationToken.None);
+
+                Assert.NotNull(error);
+                Assert.True(IsTimeoutException(error));
+            }
+        }
+
+        public class when_the_stopping_token_is_cancelled
+        {
+            [Fact]
+            public async Task throws_operation_canceled_exception()
+            {
+                var checkpoint = new Checkpoint(1, "test", "test", "test", 1, 2, 0, CheckpointStatus.Active);
+                var subscription = new Subscription("test")
+                {
+                    HandlerDelegate = (IReadOnlyList<IMessageContext> _, CancellationToken ct) =>
+                        Task.Delay(TimeSpan.FromMilliseconds(2), ct)
+                };
+                subscription.RegisterMessageType<TestMessage>();
+                subscription.BuildHandler();
+                var options = new BeckettOptions
+                {
+                    Subscriptions =
+                    {
+                        ReservationTimeout = TimeSpan.FromMilliseconds(1)
+                    }
+                };
+                var messageStore = Substitute.For<IMessageStore>();
+                var checkpointProcessor = BuildCheckpointProcessor(options, messageStore);
+                var parentCts = new CancellationTokenSource();
+                var innerCts = CancellationTokenSource.CreateLinkedTokenSource(parentCts.Token);
+
+                messageStore.ReadStream("test", Arg.Any<ReadOptions>(), Arg.Any<CancellationToken>())
+                    .Returns(new MessageStream("test", 2, [BuildMessageContext()], messageStore.AppendToStream));
+                await parentCts.CancelAsync();
+
+                await Assert.ThrowsAsync<OperationCanceledException>(() => checkpointProcessor.Process(1, checkpoint, subscription, innerCts.Token));
+            }
+        }
+
+        public class when_checkpoint_is_retry_or_failure
+        {
+            public class when_messages_to_process_is_less_than_batch_size
+            {
+                [Fact]
+                public async Task only_reads_messages_up_to_stream_version()
+                {
+                    var checkpoint = new Checkpoint(1, "test", "test", "test", 1, 10, 0, CheckpointStatus.Retry);
+                    var subscription = new Subscription("test")
+                    {
+                        HandlerDelegate = (IReadOnlyList<IMessageContext> _) => { }
+                    };
+                    subscription.RegisterMessageType<TestMessage>();
+                    subscription.BuildHandler();
+                    var options = new BeckettOptions
+                    {
+                        Subscriptions =
+                        {
+                            SubscriptionStreamBatchSize = 10
+                        }
+                    };
+                    var messageStore = Substitute.For<IMessageStore>();
+                    var checkpointProcessor = BuildCheckpointProcessor(options, messageStore);
+
+                    await checkpointProcessor.Process(1, checkpoint, subscription, CancellationToken.None);
+
+                    await messageStore.Received().ReadStream(
+                        "test",
+                        Arg.Is<ReadOptions>(x => x.StartingStreamPosition == 1 && x.EndingStreamPosition == 10),
+                        CancellationToken.None
+                    );
+                }
+            }
+
+            public class when_messages_to_process_exceeds_batch_size
+            {
+                [Fact]
+                public async Task only_reads_messages_up_to_batch_size()
+                {
+                    var checkpoint = new Checkpoint(1, "test", "test", "test", 1, 20, 0, CheckpointStatus.Retry);
+                    var subscription = new Subscription("test")
+                    {
+                        HandlerDelegate = (IReadOnlyList<IMessageContext> _) => { }
+                    };
+                    subscription.RegisterMessageType<TestMessage>();
+                    subscription.BuildHandler();
+                    var options = new BeckettOptions
+                    {
+                        Subscriptions =
+                        {
+                            SubscriptionStreamBatchSize = 10
+                        }
+                    };
+                    var messageStore = Substitute.For<IMessageStore>();
+                    var checkpointProcessor = BuildCheckpointProcessor(options, messageStore);
+
+                    await checkpointProcessor.Process(1, checkpoint, subscription, CancellationToken.None);
+
+                    await messageStore.Received().ReadStream(
+                        "test",
+                        Arg.Is<ReadOptions>(x => x.StartingStreamPosition == 1 && x.EndingStreamPosition == 11),
+                        CancellationToken.None
+                    );
+                }
+            }
+        }
+    }
+
+    private static MessageContext BuildMessageContext() => new(
+        Guid.NewGuid().ToString(),
+        "test",
+        1,
+        1,
+        "test-message",
+        JsonDocument.Parse("{}"),
+        JsonDocument.Parse("{}"),
+        DateTimeOffset.UtcNow
+    );
+
+    private static bool IsTimeoutException(RecordCheckpointError x)
+    {
+        if (x.Error.RootElement.TryGetProperty("Type", out var typeProperty))
+        {
+            return typeProperty.GetString() == typeof(TimeoutException).FullName;
+        }
+
+        return false;
+    }
+
+    private static CheckpointProcessor BuildCheckpointProcessor(
+        BeckettOptions options,
+        IMessageStore messageStore,
+        IPostgresDatabase? database = null
+    )
+    {
+        database ??= Substitute.For<IPostgresDatabase>();
+        var serviceProvider = new ServiceCollection().BuildServiceProvider();
         var instrumentation = Substitute.For<IInstrumentation>();
         var logger = Substitute.For<ILogger<CheckpointProcessor>>();
 
         return new CheckpointProcessor(messageStore, database, serviceProvider, options, instrumentation, logger);
-    }
-
-    public record TestMessage;
-
-    public class MessageTypes : IDisposable
-    {
-        public MessageTypes()
-        {
-            MessageTypeMap.Map<TestMessage>("test_message");
-        }
-
-        public void Dispose()
-        {
-            MessageTypeMap.Clear();
-        }
     }
 }

--- a/src/Beckett/Subscriptions/Queries/RecordCheckpointError.cs
+++ b/src/Beckett/Subscriptions/Queries/RecordCheckpointError.cs
@@ -6,38 +6,38 @@ using NpgsqlTypes;
 
 namespace Beckett.Subscriptions.Queries;
 
-public class RecordCheckpointError(
-    long id,
-    long streamPosition,
-    CheckpointStatus status,
-    int attempt,
-    JsonDocument error,
-    DateTimeOffset? processAt,
-    PostgresOptions options
+public record RecordCheckpointError(
+    long Id,
+    long StreamPosition,
+    CheckpointStatus Status,
+    int Attempt,
+    JsonDocument Error,
+    DateTimeOffset? ProcessAt,
+    PostgresOptions Options
 ) : IPostgresDatabaseQuery<int>
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
-        command.CommandText = $"select {options.Schema}.record_checkpoint_error($1, $2, $3, $4, $5, $6);";
+        command.CommandText = $"select {Options.Schema}.record_checkpoint_error($1, $2, $3, $4, $5, $6);";
 
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Bigint });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Bigint });
-        command.Parameters.Add(new NpgsqlParameter { DataTypeName = DataTypeNames.CheckpointStatus(options.Schema) });
+        command.Parameters.Add(new NpgsqlParameter { DataTypeName = DataTypeNames.CheckpointStatus(Options.Schema) });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Integer });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Jsonb });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.TimestampTz, IsNullable = true });
 
-        if (options.PrepareStatements)
+        if (Options.PrepareStatements)
         {
             await command.PrepareAsync(cancellationToken);
         }
 
-        command.Parameters[0].Value = id;
-        command.Parameters[1].Value = streamPosition;
-        command.Parameters[2].Value = status;
-        command.Parameters[3].Value = attempt;
-        command.Parameters[4].Value = error;
-        command.Parameters[5].Value = processAt.HasValue ? processAt.Value : DBNull.Value;
+        command.Parameters[0].Value = Id;
+        command.Parameters[1].Value = StreamPosition;
+        command.Parameters[2].Value = Status;
+        command.Parameters[3].Value = Attempt;
+        command.Parameters[4].Value = Error;
+        command.Parameters[5].Value = ProcessAt.HasValue ? ProcessAt.Value : DBNull.Value;
 
         return await command.ExecuteNonQueryAsync(cancellationToken);
     }


### PR DESCRIPTION
- important fix for nasty hidden issue resulting from HttpClient and timeouts
  - if a timeout is set on HttpClient then when a timeout occurs it throws a `TaskCanceledException` instead of a `TimeoutException` or similar
    - see here for the details: https://github.com/dotnet/runtime/issues/21965
  - since that exception derives from `OperationCanceledException` that will cause the checkpoint consumer to shut down silently, since it's using exceptions of that type to react to a SIGTERM signal sent to the host, etc...
- updated to create a linked cancellation token that is canceled after the reservation times out along with proper error handling for shutdown vs reservation timeout vs situations like HttpClient where the inner exception is a `TimeoutException`