### PR TITLE
Switch to JsonElement to relieve GC pressure

### DIFF
--- a/src/Beckett.Tests/MessageTests.cs
+++ b/src/Beckett.Tests/MessageTests.cs
@@ -9,7 +9,7 @@ public class MessageTests
     {
         var expectedId = Guid.NewGuid();
         var input = new TestMessage(expectedId);
-        var expectedData = JsonDocument.Parse(JsonSerializer.Serialize(input));
+        var expectedData = JsonDocument.Parse(JsonSerializer.Serialize(input)).RootElement;
 
         var message = new Message(input);
 

--- a/src/Beckett.Tests/Messages/MessageUpcasterTests.cs
+++ b/src/Beckett.Tests/Messages/MessageUpcasterTests.cs
@@ -20,7 +20,7 @@ public sealed class MessageUpcasterTests : IDisposable
     [Fact]
     public void returns_original_data_if_no_upcaster_is_registered_for_type_name()
     {
-        var expected = JsonDocument.Parse(@"{""Name"":""Value""}");
+        var expected = JsonDocument.Parse(@"{""Name"":""Value""}").RootElement;
 
         var result = MessageUpcaster.Upcast("message-type", expected);
 
@@ -32,7 +32,7 @@ public sealed class MessageUpcasterTests : IDisposable
     {
         MessageUpcaster.Register("old-type", "new-type", x => x);
 
-        var result = MessageUpcaster.Upcast("old-type", JsonDocument.Parse("{}"));
+        var result = MessageUpcaster.Upcast("old-type", EmptyJsonElement.Instance);
 
         Assert.Equal("new-type", result.TypeName);
     }
@@ -61,7 +61,7 @@ public sealed class MessageUpcasterTests : IDisposable
             }
         );
 
-        var dataV1 = JsonDocument.Parse($@"{{""PropertyV1"":""{expectedValue}""}}");
+        var dataV1 = JsonDocument.Parse($@"{{""PropertyV1"":""{expectedValue}""}}").RootElement;
 
         var result = MessageUpcaster.Upcast("type-v1", dataV1);
 
@@ -132,7 +132,7 @@ public sealed class MessageUpcasterTests : IDisposable
             }
         );
 
-        var dataV1 = JsonDocument.Parse($@"{{""PropertyV1"":""{expectedValue}""}}");
+        var dataV1 = JsonDocument.Parse($@"{{""PropertyV1"":""{expectedValue}""}}").RootElement;
 
         var result = MessageUpcaster.Upcast("type-v1", dataV1);
 

--- a/src/Beckett.Tests/Subscriptions/CheckpointProcessorTests.cs
+++ b/src/Beckett.Tests/Subscriptions/CheckpointProcessorTests.cs
@@ -408,8 +408,8 @@ public class CheckpointProcessorTests
         1,
         1,
         "test-message",
-        JsonDocument.Parse("{}"),
-        JsonDocument.Parse("{}"),
+        EmptyJsonElement.Instance,
+        EmptyJsonElement.Instance,
         DateTimeOffset.UtcNow
     );
 

--- a/src/Beckett.Tests/Subscriptions/SubscriptionHandlerTests.cs
+++ b/src/Beckett.Tests/Subscriptions/SubscriptionHandlerTests.cs
@@ -249,8 +249,8 @@ public class SubscriptionHandlerTests
         1,
         1,
         "test-message",
-        message != null ? MessageSerializer.Serialize(typeof(TestMessage), message) : JsonDocument.Parse("{}"),
-        JsonDocument.Parse("{}"),
+        message != null ? MessageSerializer.Serialize(typeof(TestMessage), message) : EmptyJsonElement.Instance,
+        EmptyJsonElement.Instance,
         DateTimeOffset.UtcNow
     );
 
@@ -262,8 +262,8 @@ public class SubscriptionHandlerTests
             1,
             1,
             "test-message",
-            JsonDocument.Parse("{}"),
-            JsonDocument.Parse("{}"),
+            EmptyJsonElement.Instance,
+            EmptyJsonElement.Instance,
             DateTimeOffset.UtcNow
         )
     ];

--- a/src/Beckett/Database/Models/PostgresMessage.cs
+++ b/src/Beckett/Database/Models/PostgresMessage.cs
@@ -11,12 +11,16 @@ public class PostgresMessage
     public required long StreamPosition { get; init; }
     public required long GlobalPosition { get; init; }
     public required string Type { get; init; }
-    public required JsonDocument Data { get; init; }
-    public required JsonDocument Metadata { get; init; }
+    public required JsonElement Data { get; init; }
+    public required JsonElement Metadata { get; init; }
     public required DateTimeOffset Timestamp { get; init; }
 
-    public static PostgresMessage From(NpgsqlDataReader reader) =>
-        new()
+    public static PostgresMessage From(NpgsqlDataReader reader)
+    {
+        using var data = reader.GetFieldValue<JsonDocument>(6);
+        using var metadata = reader.GetFieldValue<JsonDocument>(7);
+
+        return new PostgresMessage
         {
             Id = reader.GetFieldValue<Guid>(0),
             StreamName = reader.GetFieldValue<string>(1),
@@ -24,8 +28,9 @@ public class PostgresMessage
             StreamPosition = reader.GetFieldValue<long>(3),
             GlobalPosition = reader.GetFieldValue<long>(4),
             Type = reader.GetFieldValue<string>(5),
-            Data = reader.GetFieldValue<JsonDocument>(6),
-            Metadata = reader.GetFieldValue<JsonDocument>(7),
+            Data = data.RootElement.Clone(),
+            Metadata = metadata.RootElement.Clone(),
             Timestamp = reader.GetFieldValue<DateTimeOffset>(8)
         };
+    }
 }

--- a/src/Beckett/Database/Models/PostgresScheduledMessage.cs
+++ b/src/Beckett/Database/Models/PostgresScheduledMessage.cs
@@ -9,22 +9,27 @@ public class PostgresScheduledMessage
     public required Guid Id { get; init; }
     public required string StreamName { get; init; }
     public required string Type { get; init; }
-    public required JsonDocument Data { get; init; }
-    public required JsonDocument Metadata { get; init; }
+    public required JsonElement Data { get; init; }
+    public required JsonElement Metadata { get; init; }
     public required DateTimeOffset DeliverAt { get; init; }
     public required DateTimeOffset Timestamp { get; init; }
 
-    public static PostgresScheduledMessage From(NpgsqlDataReader reader) =>
-        new()
+    public static PostgresScheduledMessage From(NpgsqlDataReader reader)
+    {
+        using var data = reader.GetFieldValue<JsonDocument>(3);
+        using var metadata = reader.GetFieldValue<JsonDocument>(4);
+
+        return new PostgresScheduledMessage
         {
             Id = reader.GetFieldValue<Guid>(0),
             StreamName = reader.GetFieldValue<string>(1),
             Type = reader.GetFieldValue<string>(2),
-            Data = reader.GetFieldValue<JsonDocument>(3),
-            Metadata = reader.GetFieldValue<JsonDocument>(4),
+            Data = data.RootElement.Clone(),
+            Metadata = metadata.RootElement.Clone(),
             DeliverAt = reader.GetFieldValue<DateTimeOffset>(5),
             Timestamp = reader.GetFieldValue<DateTimeOffset>(6)
         };
+    }
 
     public Message ToMessage() => new(Type, Data, Metadata.ToMetadataDictionary());
 }

--- a/src/Beckett/Database/Types/MessageType.cs
+++ b/src/Beckett/Database/Types/MessageType.cs
@@ -8,8 +8,8 @@ public class MessageType
     public required Guid Id { get; init; }
     public required string StreamName { get; init; }
     public required string Type { get; init; }
-    public required JsonDocument Data { get; init; }
-    public required JsonDocument Metadata { get; init; }
+    public required JsonElement Data { get; init; }
+    public required JsonElement Metadata { get; init; }
     public long? ExpectedVersion { get; init; }
 
     public static MessageType From(

--- a/src/Beckett/Database/Types/RetryType.cs
+++ b/src/Beckett/Database/Types/RetryType.cs
@@ -6,7 +6,7 @@ namespace Beckett.Database.Types;
 public class RetryType
 {
     public int Attempt { get; init; }
-    public JsonDocument Error { get; init; } = null!;
+    public JsonElement Error { get; init; }
     public DateTimeOffset Timestamp { get; init; }
 
     public ExceptionData GetException() => ExceptionData.FromJson(Error)!;

--- a/src/Beckett/Database/Types/ScheduledMessageType.cs
+++ b/src/Beckett/Database/Types/ScheduledMessageType.cs
@@ -6,8 +6,8 @@ public class ScheduledMessageType
 {
     public Guid Id { get; init; }
     public string Type { get; init; } = null!;
-    public JsonDocument Data { get; init; } = null!;
-    public JsonDocument Metadata { get; init; } = null!;
+    public JsonElement Data { get; init; }
+    public JsonElement Metadata { get; init; }
     public DateTimeOffset DeliverAt { get; init; } = DateTimeOffset.UtcNow;
 
     public static ScheduledMessageType From(

--- a/src/Beckett/IMessageContext.cs
+++ b/src/Beckett/IMessageContext.cs
@@ -32,12 +32,12 @@ public interface IMessageContext
     /// <summary>
     /// Message data
     /// </summary>
-    JsonDocument Data { get; }
+    JsonElement Data { get; }
 
     /// <summary>
     /// Message metadata
     /// </summary>
-    JsonDocument Metadata { get; }
+    JsonElement Metadata { get; }
 
     /// <summary>
     /// The timestamp of when the message was written to the message store

--- a/src/Beckett/Message.cs
+++ b/src/Beckett/Message.cs
@@ -8,7 +8,6 @@ namespace Beckett;
 /// </summary>
 public class Message
 {
-    private static readonly JsonDocument EmptyJsonDocument = JsonDocument.Parse("{}");
     private static readonly Type MetadataDictionaryType = typeof(Dictionary<string, string>);
 
     /// <summary>
@@ -46,10 +45,9 @@ public class Message
     /// <param name="type">Message type</param>
     /// <param name="data">Message data</param>
     /// <param name="metadata">Message metadata</param>
-    public Message(string type, JsonDocument data, Dictionary<string, string>? metadata = null)
+    public Message(string type, JsonElement data, Dictionary<string, string>? metadata = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(type);
-        ArgumentNullException.ThrowIfNull(data);
 
         Type = type;
         Data = data;
@@ -57,7 +55,7 @@ public class Message
     }
 
     public string Type { get; }
-    public JsonDocument Data { get; }
+    public JsonElement Data { get; }
     public Dictionary<string, string> Metadata { get; }
 
     public Message WithMetadata(string key, string? value)
@@ -80,6 +78,6 @@ public class Message
         tenant
     );
 
-    internal JsonDocument SerializedMetadata =>
-        Metadata.Count > 0 ? MessageSerializer.Serialize(MetadataDictionaryType, Metadata) : EmptyJsonDocument;
+    internal JsonElement SerializedMetadata =>
+        Metadata.Count > 0 ? MessageSerializer.Serialize(MetadataDictionaryType, Metadata) : EmptyJsonElement.Instance;
 }

--- a/src/Beckett/MessageStorage/StreamMessage.cs
+++ b/src/Beckett/MessageStorage/StreamMessage.cs
@@ -8,7 +8,7 @@ public record StreamMessage(
     long StreamPosition,
     long GlobalPosition,
     string Type,
-    JsonDocument Data,
-    JsonDocument Metadata,
+    JsonElement Data,
+    JsonElement Metadata,
     DateTimeOffset Timestamp
 );

--- a/src/Beckett/Messages/EmptyJsonElement.cs
+++ b/src/Beckett/Messages/EmptyJsonElement.cs
@@ -1,0 +1,8 @@
+using System.Text.Json;
+
+namespace Beckett.Messages;
+
+public static class EmptyJsonElement
+{
+    public static readonly JsonElement Instance = JsonDocument.Parse("{}").RootElement.Clone();
+}

--- a/src/Beckett/Messages/JsonDocumentExtensions.cs
+++ b/src/Beckett/Messages/JsonDocumentExtensions.cs
@@ -4,7 +4,7 @@ namespace Beckett.Messages;
 
 public static class JsonDocumentExtensions
 {
-    public static Dictionary<string, string> ToMetadataDictionary(this JsonDocument metadata)
+    public static Dictionary<string, string> ToMetadataDictionary(this JsonElement metadata)
     {
         return metadata.Deserialize<Dictionary<string, string>>(MessageSerializer.Options) ??
                new Dictionary<string, string>();

--- a/src/Beckett/Messages/MessageContext.cs
+++ b/src/Beckett/Messages/MessageContext.cs
@@ -9,16 +9,14 @@ public record MessageContext(
     long StreamPosition,
     long GlobalPosition,
     string Type,
-    JsonDocument Data,
-    JsonDocument Metadata,
+    JsonElement Data,
+    JsonElement Metadata,
     DateTimeOffset Timestamp,
     Type? MessageType = null,
     object? Message = null,
     Dictionary<string, string>? MessageMetadata = null
 ) : IMessageContext
 {
-    private static readonly JsonDocument EmptyJsonDocument = JsonDocument.Parse("{}");
-
     private readonly Lazy<Type?> _messageType = new(() => MessageType ?? (MessageTypeMap.TryGetType(Type, out var type) ? type : null));
     private readonly Lazy<object?> _message = new(() => Message ?? MessageSerializer.Deserialize(Type, Data));
     private readonly Lazy<Dictionary<string, string>> _messageMetadata = new(MessageMetadata ?? Metadata.ToMetadataDictionary());
@@ -46,8 +44,8 @@ public record MessageContext(
         0,
         0,
         string.Empty,
-        EmptyJsonDocument,
-        EmptyJsonDocument,
+        EmptyJsonElement.Instance,
+        EmptyJsonElement.Instance,
         DateTimeOffset.UtcNow,
         message.GetType(),
         message

--- a/src/Beckett/Messages/MessageSerializer.cs
+++ b/src/Beckett/Messages/MessageSerializer.cs
@@ -11,12 +11,14 @@ public static class MessageSerializer
         Options = options;
     }
 
-    public static JsonDocument Serialize(Type messageType, object message)
+    public static JsonElement Serialize(Type messageType, object message)
     {
-        return JsonSerializer.SerializeToDocument(message, messageType, Options);
+        using var document = JsonSerializer.SerializeToDocument(message, messageType, Options);
+
+        return document.RootElement.Clone();
     }
 
-    public static object? Deserialize(string type, JsonDocument data)
+    public static object? Deserialize(string type, JsonElement data)
     {
         var result = MessageUpcaster.Upcast(type, data);
 

--- a/src/Beckett/Messages/MessageUpcaster.cs
+++ b/src/Beckett/Messages/MessageUpcaster.cs
@@ -18,7 +18,7 @@ public static class MessageUpcaster
         Upcasters.Add(new MappedType(oldTypeName, newTypeName), transformation);
     }
 
-    public static (string TypeName, JsonDocument Data) Upcast(string typeName, JsonDocument data)
+    public static (string TypeName, JsonElement Data) Upcast(string typeName, JsonElement data)
     {
         var mappedTypes = FindAllMappedTypes(typeName).ToArray();
 
@@ -27,7 +27,7 @@ public static class MessageUpcaster
             return (typeName, data);
         }
 
-        var result = JsonObject.Create(data.RootElement) ??
+        var result = JsonObject.Create(data) ??
                      throw new InvalidOperationException("Unable to create JsonObject from message data");
 
         var newTypeName = typeName;
@@ -43,7 +43,9 @@ public static class MessageUpcaster
             result = upcaster(result);
         }
 
-        return (newTypeName, JsonDocument.Parse(result.ToJsonString()));
+        using var document = JsonDocument.Parse(result.ToJsonString());
+
+        return (newTypeName, document.RootElement.Clone());
     }
 
     public static void Clear()

--- a/src/Beckett/OpenTelemetry/Instrumentation.cs
+++ b/src/Beckett/OpenTelemetry/Instrumentation.cs
@@ -169,7 +169,7 @@ public class Instrumentation : IInstrumentation, IDisposable
 
         activity.AddTag(TelemetryConstants.Message.Id, messageContext.Id);
 
-        if (messageContext.Metadata.RootElement.TryGetProperty(
+        if (messageContext.Metadata.TryGetProperty(
                 MessageConstants.Metadata.CorrelationId,
                 out var correlationIdProperty
             ))
@@ -180,7 +180,7 @@ public class Instrumentation : IInstrumentation, IDisposable
             activity.AddBaggage(TelemetryConstants.Message.CorrelationId, correlationId);
         }
 
-        if (messageContext.Metadata.RootElement.TryGetProperty(
+        if (messageContext.Metadata.TryGetProperty(
                 MessageConstants.Metadata.CausationId,
                 out var causationIdProperty
             ))
@@ -190,7 +190,7 @@ public class Instrumentation : IInstrumentation, IDisposable
             activity.AddTag(TelemetryConstants.Message.CausationId, causationId);
         }
 
-        if (messageContext.Metadata.RootElement.TryGetProperty(
+        if (messageContext.Metadata.TryGetProperty(
                 MessageConstants.Metadata.Tenant,
                 out var tenantProperty
             ))
@@ -256,11 +256,11 @@ public class Instrumentation : IInstrumentation, IDisposable
         return (long)command.ExecuteScalar()!;
     }
 
-    private IEnumerable<string> ExtractTraceContextFromMetadata(JsonDocument metadata, string key)
+    private IEnumerable<string> ExtractTraceContextFromMetadata(JsonElement metadata, string key)
     {
         try
         {
-            if (metadata.RootElement.TryGetProperty(key, out var value))
+            if (metadata.TryGetProperty(key, out var value))
             {
                 if (value.ValueKind == JsonValueKind.Null)
                 {

--- a/src/Beckett/Subscriptions/Retries/ExceptionData.cs
+++ b/src/Beckett/Subscriptions/Retries/ExceptionData.cs
@@ -30,7 +30,7 @@ public record ExceptionData(string Type, string Message, List<string>? StackTrac
         );
     }
 
-    public static ExceptionData? FromJson(JsonDocument document) => document.Deserialize<ExceptionData>();
+    public static ExceptionData? FromJson(JsonElement element) => element.Deserialize<ExceptionData>();
 
     public JsonDocument ToJson() => JsonSerializer.SerializeToDocument(this);
 }


### PR DESCRIPTION
- attempt to reduce memory usage by using `JsonElement` instead of `JsonDocument`, where the latter is used for reading and constructing documents but is disposed of properly to return rented memory back to the pool