### PR TITLE
Initial stream archive / truncate support

### DIFF
--- a/db/migrations/001.sql
+++ b/db/migrations/001.sql
@@ -76,6 +76,44 @@ CREATE INDEX IF NOT EXISTS ix_messages_active_tenant_stream_category on __schema
 CREATE INDEX IF NOT EXISTS ix_messages_active_correlation_id ON __schema__.messages_active ((metadata ->> '$correlation_id'))
   WHERE metadata ->> '$correlation_id' IS NOT NULL;
 
+CREATE FUNCTION __schema__.stream_operations()
+  RETURNS trigger
+  LANGUAGE plpgsql
+AS
+$$
+BEGIN
+  IF NEW.type = '$stream_truncated' THEN
+    UPDATE __schema__.messages
+    SET archived = TRUE
+    WHERE stream_name = NEW.stream_name
+    AND stream_position < NEW.stream_position;
+
+    IF FOUND IS FALSE THEN
+      RETURN NULL;
+    END IF;
+  END IF;
+
+  IF NEW.type = '$stream_archived' THEN
+    UPDATE __schema__.messages
+    SET archived = TRUE
+    WHERE stream_name = NEW.stream_name
+    AND stream_position < NEW.stream_position;
+
+    IF FOUND IS FALSE THEN
+      RETURN NULL;
+    END IF;
+  END IF;
+
+  RETURN new;
+END;
+$$;
+
+CREATE TRIGGER stream_operations
+  BEFORE INSERT
+  ON __schema__.messages
+  FOR EACH ROW
+EXECUTE FUNCTION __schema__.stream_operations();
+
 CREATE OR REPLACE FUNCTION __schema__.stream_hash(
   _stream_name text
 )

--- a/db/versions/0.16.16.sql
+++ b/db/versions/0.16.16.sql
@@ -1,0 +1,38 @@
+-- support archiving and truncating streams
+CREATE FUNCTION beckett.stream_operations()
+  RETURNS trigger
+  LANGUAGE plpgsql
+AS
+$$
+BEGIN
+  IF NEW.type = '$stream_truncated' THEN
+    UPDATE beckett.messages
+    SET archived = TRUE
+    WHERE stream_name = NEW.stream_name
+    AND stream_position < NEW.stream_position;
+
+    IF FOUND IS FALSE THEN
+      RETURN NULL;
+    END IF;
+  END IF;
+
+  IF NEW.type = '$stream_archived' THEN
+    UPDATE beckett.messages
+    SET archived = TRUE
+    WHERE stream_name = NEW.stream_name
+      AND stream_position < NEW.stream_position;
+
+    IF FOUND IS FALSE THEN
+      RETURN NULL;
+    END IF;
+  END IF;
+
+  RETURN new;
+END;
+$$;
+
+CREATE TRIGGER stream_operations
+  BEFORE INSERT
+  ON beckett.messages
+  FOR EACH ROW
+EXECUTE FUNCTION beckett.stream_operations();

--- a/src/Beckett/Messages/MessageTypeMap.cs
+++ b/src/Beckett/Messages/MessageTypeMap.cs
@@ -10,6 +10,11 @@ public static class MessageTypeMap
     private static GetNameFallback? _getNameFallback;
     private static TryGetTypeFallback? _tryGetTypeFallback;
 
+    static MessageTypeMap()
+    {
+        MapSystemTypes();
+    }
+
     public static void Configure(GetNameFallback getNameFallback)
     {
         _getNameFallback = getNameFallback;
@@ -94,6 +99,12 @@ public static class MessageTypeMap
         NameToTypeMap.Clear();
         TypeToNameMap.Clear();
     }
+
+    private static void MapSystemTypes()
+    {
+        Map<StreamArchived>("$stream_archived");
+        Map<StreamTruncated>("$stream_truncated");
+    }
 }
 
 public delegate string GetNameFallback(Type type);
@@ -101,9 +112,6 @@ public delegate string GetNameFallback(Type type);
 public delegate Type? TryGetTypeFallback(string name);
 
 public class UnknownTypeException(string name) : Exception($"Unknown type name: {name}");
-
-public class MessageTypesCannotBeMappedToThemselvesException(string name)
-    : Exception($"Message types cannot be mapped to themselves: {name}.");
 
 public class MessageTypeAlreadyMappedException(string name, string existingName)
     : Exception($"Message type name '{name}' is already mapped to {existingName}.");

--- a/src/Beckett/StreamArchived.cs
+++ b/src/Beckett/StreamArchived.cs
@@ -1,0 +1,6 @@
+namespace Beckett;
+
+/// <summary>
+/// Use this message type to archive a stream
+/// </summary>
+public record StreamArchived;

--- a/src/Beckett/StreamTruncated.cs
+++ b/src/Beckett/StreamTruncated.cs
@@ -1,0 +1,6 @@
+namespace Beckett;
+
+/// <summary>
+/// Use this message type to truncate a stream
+/// </summary>
+public record StreamTruncated;


### PR DESCRIPTION
- add initial support for archiving and truncating streams using well known message types - `$stream_archived` and `$stream_truncated`
- archiving and truncating both just set all messages in the stream to archived
  - for archiving the eventual goal is to have support in the append call to prevent archived streams from being written to, right now there is just a need to start managing data - once a workflow is complete, archive a stream, etc...
  - truncating will have a range of options eventually - truncate before a given position, max count, max age, but right now the target use case is being able to truncate a stream in it's entirety and then write a new message, i.e. "only keep one message in this stream at any given time"