### PR TITLE
Checkpoint stream retry support

### DIFF
--- a/db/migrations/001.sql
+++ b/db/migrations/001.sql
@@ -415,6 +415,14 @@ CREATE TYPE __schema__.checkpoint_status AS ENUM (
   'failed'
 );
 
+CREATE TYPE __schema__.checkpoint_stream_retry AS
+(
+  stream_name text,
+  stream_version bigint,
+  stream_position bigint,
+  error jsonb
+);
+
 CREATE TABLE IF NOT EXISTS __schema__.subscriptions
 (
   group_name text NOT NULL,
@@ -423,13 +431,14 @@ CREATE TABLE IF NOT EXISTS __schema__.subscriptions
   PRIMARY KEY (group_name, name)
 );
 
-CREATE INDEX ix_subscriptions_active ON beckett.subscriptions (group_name, name, status) WHERE status = 'active';
+CREATE INDEX ix_subscriptions_active ON __schema__.subscriptions (group_name, name, status) WHERE status = 'active';
 
 GRANT UPDATE, DELETE ON __schema__.subscriptions TO beckett;
 
 CREATE TABLE IF NOT EXISTS __schema__.checkpoints
 (
   id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  parent_id bigint NULL REFERENCES __schema__.checkpoints (id) ON DELETE CASCADE,
   stream_version bigint NOT NULL DEFAULT 0,
   stream_position bigint NOT NULL DEFAULT 0,
   created_at timestamp with time zone DEFAULT now(),
@@ -445,13 +454,15 @@ CREATE TABLE IF NOT EXISTS __schema__.checkpoints
   UNIQUE (group_name, name, stream_name)
 );
 
-CREATE INDEX IF NOT EXISTS ix_checkpoints_to_process ON beckett.checkpoints (group_name, process_at, reserved_until)
+CREATE INDEX IF NOT EXISTS ix_checkpoints_to_process ON __schema__.checkpoints (group_name, process_at, reserved_until)
   WHERE process_at IS NOT NULL AND reserved_until IS NULL;
 
 CREATE INDEX IF NOT EXISTS ix_checkpoints_reserved ON __schema__.checkpoints (group_name, reserved_until)
   WHERE reserved_until IS NOT NULL;
 
-CREATE INDEX IF NOT EXISTS ix_checkpoints_metrics ON beckett.checkpoints (status, lagging, group_name, name);
+CREATE INDEX IF NOT EXISTS ix_checkpoints_metrics ON __schema__.checkpoints (status, lagging, group_name, name);
+
+CREATE INDEX IF NOT EXISTS ix_checkpoints_parent_id ON __schema__.checkpoints (parent_id, status, stream_name) WHERE parent_id IS NOT NULL;
 
 CREATE FUNCTION __schema__.checkpoint_preprocessor()
   RETURNS trigger
@@ -613,6 +624,23 @@ SELECT stream_version
 FROM new_checkpoint;
 $$;
 
+CREATE OR REPLACE FUNCTION __schema__.get_checkpoint_blocked_streams (
+  _parent_id bigint,
+  _stream_names text[]
+)
+  RETURNS TABLE(
+    stream_name text
+  )
+  LANGUAGE sql
+AS
+$$
+SELECT stream_name
+FROM __schema__.checkpoints
+WHERE parent_id = _parent_id
+AND status IN ('retry', 'failed')
+AND stream_name = ANY(_stream_names);
+$$;
+
 CREATE OR REPLACE FUNCTION __schema__.lock_checkpoint(
   _group_name text,
   _name text,
@@ -657,6 +685,38 @@ BEGIN
         row(_attempt, _error, now())::__schema__.retry
       )
   WHERE id = _id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION __schema__.record_checkpoint_stream_retries (
+  _checkpoint_id bigint,
+  _retries __schema__.checkpoint_stream_retry[]
+)
+  RETURNS void
+  LANGUAGE plpgsql
+AS
+$$
+DECLARE
+  _parent_id bigint;
+  _parent_group_name text;
+  _parent_name text;
+BEGIN
+SELECT id, group_name, name
+INTO _parent_id, _parent_group_name, _parent_name
+FROM __schema__.checkpoints
+WHERE id = _checkpoint_id;
+
+INSERT INTO __schema__.checkpoints (parent_id, group_name, name, stream_name, stream_version, stream_position, status, process_at, retries)
+SELECT _parent_id,
+       _parent_group_name,
+       _parent_name,
+       r.stream_name,
+       r.stream_version,
+       r.stream_position,
+       'retry',
+       now(),
+       array[row(0, r.error, now())::__schema__.retry]
+FROM unnest(_retries) AS r;
 END;
 $$;
 
@@ -710,12 +770,35 @@ BEGIN
 END;
 $$;
 
+CREATE OR REPLACE FUNCTION __schema__.reserve_checkpoint(
+  _id bigint,
+  _reservation_timeout interval
+)
+  RETURNS bigint
+  LANGUAGE sql
+AS
+$$
+UPDATE __schema__.checkpoints c
+SET reserved_until = now() + _reservation_timeout
+FROM (
+  SELECT c.id
+  FROM __schema__.checkpoints c
+  WHERE c.id = _id
+  AND c.reserved_until IS NULL
+  FOR UPDATE
+  SKIP LOCKED
+) as d
+WHERE c.id = d.id
+RETURNING c.stream_version;
+$$;
+
 CREATE OR REPLACE FUNCTION __schema__.reserve_next_available_checkpoint(
   _group_name text,
   _reservation_timeout interval
 )
   RETURNS TABLE (
     id bigint,
+    parent_id bigint,
     group_name text,
     name text,
     stream_name text,
@@ -745,6 +828,7 @@ FROM (
 WHERE c.id = d.id
 RETURNING
   c.id,
+  c.parent_id,
   c.group_name,
   c.name,
   c.stream_name,
@@ -783,22 +867,6 @@ SET stream_position = CASE WHEN stream_position + 1 > stream_version THEN stream
 WHERE id = _id;
 $$;
 
-CREATE OR REPLACE FUNCTION __schema__.update_system_checkpoint_position(
-  _id bigint,
-  _position bigint
-)
-  RETURNS void
-  LANGUAGE plpgsql
-AS
-$$
-BEGIN
-  UPDATE __schema__.checkpoints
-  SET stream_version = _position,
-      stream_position = _position
-  WHERE id = _id;
-END;
-$$;
-
 CREATE OR REPLACE FUNCTION __schema__.update_checkpoint_position(
   _id bigint,
   _stream_position bigint,
@@ -815,6 +883,47 @@ BEGIN
       reserved_until = NULL,
       status = 'active',
       retries = NULL
+  WHERE id = _id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION __schema__.update_child_checkpoint_position(
+  _id bigint,
+  _stream_position bigint,
+  _stream_version bigint,
+  _process_at timestamp with time zone
+)
+  RETURNS void
+  LANGUAGE plpgsql
+AS
+$$
+BEGIN
+  IF (_process_at IS NOT NULL) THEN
+    UPDATE __schema__.checkpoints
+    SET stream_position = _stream_position,
+        stream_version = coalesce(_stream_version, stream_version),
+        process_at = _process_at,
+        reserved_until = NULL
+    WHERE id = _id;
+  ELSE
+    DELETE FROM __schema__.checkpoints
+    WHERE id = _id;
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION __schema__.update_system_checkpoint_position(
+  _id bigint,
+  _position bigint
+)
+  RETURNS void
+  LANGUAGE plpgsql
+AS
+$$
+BEGIN
+  UPDATE __schema__.checkpoints
+  SET stream_version = _position,
+      stream_position = _position
   WHERE id = _id;
 END;
 $$;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -47,6 +47,18 @@ CREATE TYPE beckett.checkpoint_status AS ENUM (
 
 
 --
+-- Name: checkpoint_stream_retry; Type: TYPE; Schema: beckett; Owner: -
+--
+
+CREATE TYPE beckett.checkpoint_stream_retry AS (
+	stream_name text,
+	stream_version bigint,
+	stream_position bigint,
+	error jsonb
+);
+
+
+--
 -- Name: message; Type: TYPE; Schema: beckett; Owner: -
 --
 
@@ -250,6 +262,21 @@ AND stream_name = _stream_name
 UNION ALL
 SELECT stream_version
 FROM new_checkpoint;
+$$;
+
+
+--
+-- Name: get_checkpoint_blocked_streams(bigint, text[]); Type: FUNCTION; Schema: beckett; Owner: -
+--
+
+CREATE FUNCTION beckett.get_checkpoint_blocked_streams(_parent_id bigint, _stream_names text[]) RETURNS TABLE(stream_name text)
+    LANGUAGE sql
+    AS $$
+SELECT stream_name
+FROM beckett.checkpoints
+WHERE parent_id = _parent_id
+AND status IN ('retry', 'failed')
+AND stream_name = ANY(_stream_names);
 $$;
 
 
@@ -552,6 +579,38 @@ $$;
 
 
 --
+-- Name: record_checkpoint_stream_retries(bigint, beckett.checkpoint_stream_retry[]); Type: FUNCTION; Schema: beckett; Owner: -
+--
+
+CREATE FUNCTION beckett.record_checkpoint_stream_retries(_checkpoint_id bigint, _retries beckett.checkpoint_stream_retry[]) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+  _parent_id bigint;
+  _parent_group_name text;
+  _parent_name text;
+BEGIN
+SELECT id, group_name, name
+INTO _parent_id, _parent_group_name, _parent_name
+FROM beckett.checkpoints
+WHERE id = _checkpoint_id;
+
+INSERT INTO beckett.checkpoints (parent_id, group_name, name, stream_name, stream_version, stream_position, status, process_at, retries)
+SELECT _parent_id,
+       _parent_group_name,
+       _parent_name,
+       r.stream_name,
+       r.stream_version,
+       r.stream_position,
+       'retry',
+       now(),
+       array[row(0, r.error, now())::beckett.retry]
+FROM unnest(_retries) AS r;
+END;
+$$;
+
+
+--
 -- Name: record_checkpoints(beckett.checkpoint[]); Type: FUNCTION; Schema: beckett; Owner: -
 --
 
@@ -604,10 +663,32 @@ $$;
 
 
 --
+-- Name: reserve_checkpoint(bigint, interval); Type: FUNCTION; Schema: beckett; Owner: -
+--
+
+CREATE FUNCTION beckett.reserve_checkpoint(_id bigint, _reservation_timeout interval) RETURNS bigint
+    LANGUAGE sql
+    AS $$
+UPDATE beckett.checkpoints c
+SET reserved_until = now() + _reservation_timeout
+FROM (
+  SELECT c.id
+  FROM beckett.checkpoints c
+  WHERE c.id = _id
+  AND c.reserved_until IS NULL
+  FOR UPDATE
+  SKIP LOCKED
+) as d
+WHERE c.id = d.id
+RETURNING c.stream_version;
+$$;
+
+
+--
 -- Name: reserve_next_available_checkpoint(text, interval); Type: FUNCTION; Schema: beckett; Owner: -
 --
 
-CREATE FUNCTION beckett.reserve_next_available_checkpoint(_group_name text, _reservation_timeout interval) RETURNS TABLE(id bigint, group_name text, name text, stream_name text, stream_position bigint, stream_version bigint, retry_attempts integer, status beckett.checkpoint_status)
+CREATE FUNCTION beckett.reserve_next_available_checkpoint(_group_name text, _reservation_timeout interval) RETURNS TABLE(id bigint, parent_id bigint, group_name text, name text, stream_name text, stream_position bigint, stream_version bigint, retry_attempts integer, status beckett.checkpoint_status)
     LANGUAGE sql
     AS $$
 UPDATE beckett.checkpoints c
@@ -628,6 +709,7 @@ FROM (
 WHERE c.id = d.id
 RETURNING
   c.id,
+  c.parent_id,
   c.group_name,
   c.name,
   c.stream_name,
@@ -826,6 +908,29 @@ $$;
 
 
 --
+-- Name: update_child_checkpoint_position(bigint, bigint, bigint, timestamp with time zone); Type: FUNCTION; Schema: beckett; Owner: -
+--
+
+CREATE FUNCTION beckett.update_child_checkpoint_position(_id bigint, _stream_position bigint, _stream_version bigint, _process_at timestamp with time zone) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  IF (_process_at IS NOT NULL) THEN
+    UPDATE beckett.checkpoints
+    SET stream_position = _stream_position,
+        stream_version = coalesce(_stream_version, stream_version),
+        process_at = _process_at,
+        reserved_until = NULL
+    WHERE id = _id;
+  ELSE
+    DELETE FROM beckett.checkpoints
+    WHERE id = _id;
+  END IF;
+END;
+$$;
+
+
+--
 -- Name: update_system_checkpoint_position(bigint, bigint); Type: FUNCTION; Schema: beckett; Owner: -
 --
 
@@ -847,6 +952,7 @@ $$;
 
 CREATE TABLE beckett.checkpoints (
     id bigint NOT NULL,
+    parent_id bigint,
     stream_version bigint DEFAULT 0 NOT NULL,
     stream_position bigint DEFAULT 0 NOT NULL,
     created_at timestamp with time zone DEFAULT now(),
@@ -1112,6 +1218,13 @@ CREATE INDEX ix_checkpoints_metrics ON beckett.checkpoints USING btree (status, 
 
 
 --
+-- Name: ix_checkpoints_parent_id; Type: INDEX; Schema: beckett; Owner: -
+--
+
+CREATE INDEX ix_checkpoints_parent_id ON beckett.checkpoints USING btree (parent_id, status, stream_name) WHERE (parent_id IS NOT NULL);
+
+
+--
 -- Name: ix_checkpoints_reserved; Type: INDEX; Schema: beckett; Owner: -
 --
 
@@ -1221,6 +1334,14 @@ CREATE TRIGGER checkpoint_preprocessor BEFORE INSERT OR UPDATE ON beckett.checkp
 --
 
 CREATE TRIGGER stream_operations BEFORE INSERT ON beckett.messages FOR EACH ROW EXECUTE FUNCTION beckett.stream_operations();
+
+
+--
+-- Name: checkpoints checkpoints_parent_id_fkey; Type: FK CONSTRAINT; Schema: beckett; Owner: -
+--
+
+ALTER TABLE ONLY beckett.checkpoints
+    ADD CONSTRAINT checkpoints_parent_id_fkey FOREIGN KEY (parent_id) REFERENCES beckett.checkpoints(id) ON DELETE CASCADE;
 
 
 --

--- a/db/versions/0.17.1.sql
+++ b/db/versions/0.17.1.sql
@@ -1,0 +1,160 @@
+ALTER TABLE beckett.checkpoints ADD COLUMN IF NOT EXISTS parent_id bigint NULL;
+
+ALTER TABLE beckett.checkpoints ADD CONSTRAINT checkpoints_parent_id_fkey
+FOREIGN KEY (parent_id)
+REFERENCES beckett.checkpoints (id)
+ON DELETE CASCADE;
+
+CREATE INDEX ix_checkpoints_parent_id ON beckett.checkpoints (parent_id, status, stream_name) WHERE parent_id IS NOT NULL;
+
+CREATE TYPE beckett.checkpoint_stream_retry AS
+(
+  stream_name text,
+  stream_version bigint,
+  stream_position bigint,
+  error jsonb
+);
+
+CREATE OR REPLACE FUNCTION beckett.get_checkpoint_blocked_streams (
+  _parent_id bigint,
+  _stream_names text[]
+)
+  RETURNS TABLE(
+    stream_name text
+  )
+  LANGUAGE sql
+AS
+$$
+SELECT stream_name
+FROM beckett.checkpoints
+WHERE parent_id = _parent_id
+AND status IN ('retry', 'failed')
+AND stream_name = ANY(_stream_names);
+$$;
+
+CREATE OR REPLACE FUNCTION beckett.record_checkpoint_stream_retries (
+  _checkpoint_id bigint,
+  _retries beckett.checkpoint_stream_retry[]
+)
+  RETURNS void
+  LANGUAGE plpgsql
+AS
+$$
+DECLARE
+  _parent_id bigint;
+  _parent_group_name text;
+  _parent_name text;
+BEGIN
+SELECT id, group_name, name
+INTO _parent_id, _parent_group_name, _parent_name
+FROM beckett.checkpoints
+WHERE id = _checkpoint_id;
+
+INSERT INTO beckett.checkpoints (parent_id, group_name, name, stream_name, stream_version, stream_position, status, process_at, retries)
+SELECT _parent_id,
+       _parent_group_name,
+       _parent_name,
+       r.stream_name,
+       r.stream_version,
+       r.stream_position,
+       'retry',
+       now(),
+       array[row(0, r.error, now())::beckett.retry]
+FROM unnest(_retries) AS r;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION beckett.update_child_checkpoint_position(
+  _id bigint,
+  _stream_position bigint,
+  _stream_version bigint,
+  _process_at timestamp with time zone
+)
+  RETURNS void
+  LANGUAGE plpgsql
+AS
+$$
+BEGIN
+  IF (_process_at IS NOT NULL) THEN
+    UPDATE beckett.checkpoints
+    SET stream_position = _stream_position,
+        stream_version = coalesce(_stream_version, stream_version),
+        process_at = _process_at,
+        reserved_until = NULL
+    WHERE id = _id;
+  ELSE
+    DELETE FROM beckett.checkpoints
+    WHERE id = _id;
+  END IF;
+END;
+$$;
+
+DROP FUNCTION beckett.reserve_next_available_checkpoint(text, interval);
+
+CREATE OR REPLACE FUNCTION beckett.reserve_next_available_checkpoint(
+  _group_name text,
+  _reservation_timeout interval
+)
+  RETURNS TABLE (
+    id bigint,
+    parent_id bigint,
+    group_name text,
+    name text,
+    stream_name text,
+    stream_position bigint,
+    stream_version bigint,
+    retry_attempts int,
+    status beckett.checkpoint_status
+  )
+  LANGUAGE sql
+AS
+$$
+UPDATE beckett.checkpoints c
+SET reserved_until = now() + _reservation_timeout
+FROM (
+  SELECT c.id
+  FROM beckett.checkpoints c
+  INNER JOIN beckett.subscriptions s ON c.group_name = s.group_name AND c.name = s.name
+  WHERE c.group_name = _group_name
+  AND c.process_at <= now()
+  AND c.reserved_until IS NULL
+  AND s.status = 'active'
+  ORDER BY c.process_at
+  LIMIT 1
+  FOR UPDATE
+  SKIP LOCKED
+) as d
+WHERE c.id = d.id
+RETURNING
+  c.id,
+  c.parent_id,
+  c.group_name,
+  c.name,
+  c.stream_name,
+  c.stream_position,
+  c.stream_version,
+  coalesce(array_length(c.retries, 1), 0) as retry_attempts,
+  c.status;
+$$;
+
+CREATE OR REPLACE FUNCTION beckett.reserve_checkpoint(
+  _id bigint,
+  _reservation_timeout interval
+)
+  RETURNS bigint
+  LANGUAGE sql
+AS
+$$
+UPDATE beckett.checkpoints c
+SET reserved_until = now() + _reservation_timeout
+FROM (
+  SELECT c.id
+  FROM beckett.checkpoints c
+  WHERE c.id = _id
+  AND c.reserved_until IS NULL
+  FOR UPDATE
+  SKIP LOCKED
+) as d
+WHERE c.id = d.id
+RETURNING c.stream_version;
+$$;

--- a/src/Beckett.Tests/Subscriptions/CheckpointProcessorTests.cs
+++ b/src/Beckett.Tests/Subscriptions/CheckpointProcessorTests.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Beckett.Database;
 using Beckett.Messages;
 using Beckett.MessageStorage;
@@ -20,7 +19,7 @@ public class CheckpointProcessorTests
             [Fact]
             public async Task only_reads_messages_up_to_stream_version()
             {
-                var checkpoint = new Checkpoint(1, "test", "test", "test", 0, 10, 0, CheckpointStatus.Active);
+                var checkpoint = new Checkpoint(1, null, "test", "test", "test", 0, 10, 0, CheckpointStatus.Active);
                 var subscription = new Subscription("test")
                 {
                     HandlerDelegate = (IMessageContext _) => { }
@@ -52,7 +51,7 @@ public class CheckpointProcessorTests
             [Fact]
             public async Task only_reads_messages_up_to_batch_size()
             {
-                var checkpoint = new Checkpoint(1, "test", "test", "test", 0, 20, 0, CheckpointStatus.Active);
+                var checkpoint = new Checkpoint(1, null, "test", "test", "test", 0, 20, 0, CheckpointStatus.Active);
                 var subscription = new Subscription("test")
                 {
                     HandlerDelegate = (IMessageContext _) => { }
@@ -87,7 +86,7 @@ public class CheckpointProcessorTests
             [Fact]
             public async Task throws_timeout_exception()
             {
-                var checkpoint = new Checkpoint(1, "test", "test", "test", 1, 2, 0, CheckpointStatus.Active);
+                var checkpoint = new Checkpoint(1, null, "test", "test", "test", 1, 2, 0, CheckpointStatus.Active);
                 var subscription = new Subscription("test")
                 {
                     HandlerDelegate = async (IMessageContext _, CancellationToken ct) =>
@@ -125,7 +124,7 @@ public class CheckpointProcessorTests
             [Fact]
             public async Task throws_timeout_exception()
             {
-                var checkpoint = new Checkpoint(1, "test", "test", "test", 1, 2, 0, CheckpointStatus.Active);
+                var checkpoint = new Checkpoint(1, null, "test", "test", "test", 1, 2, 0, CheckpointStatus.Active);
                 var subscription = new Subscription("test")
                 {
                     HandlerDelegate = (IMessageContext _, CancellationToken ct) =>
@@ -163,7 +162,7 @@ public class CheckpointProcessorTests
             [Fact]
             public async Task throws_operation_canceled_exception()
             {
-                var checkpoint = new Checkpoint(1, "test", "test", "test", 1, 2, 0, CheckpointStatus.Active);
+                var checkpoint = new Checkpoint(1, null, "test", "test", "test", 1, 2, 0, CheckpointStatus.Active);
                 var subscription = new Subscription("test")
                 {
                     HandlerDelegate = async (IMessageContext _, CancellationToken ct) =>
@@ -200,7 +199,7 @@ public class CheckpointProcessorTests
             [Fact]
             public async Task only_reads_one_message_to_retry()
             {
-                var checkpoint = new Checkpoint(1, "test", "test", "test", 1, 20, 0, CheckpointStatus.Retry);
+                var checkpoint = new Checkpoint(1, null, "test", "test", "test", 1, 20, 0, CheckpointStatus.Retry);
                 var subscription = new Subscription("test")
                 {
                     HandlerDelegate = (IMessageContext _) => { }
@@ -235,7 +234,7 @@ public class CheckpointProcessorTests
             [Fact]
             public async Task throws_timeout_exception()
             {
-                var checkpoint = new Checkpoint(1, "test", "test", "test", 1, 2, 0, CheckpointStatus.Active);
+                var checkpoint = new Checkpoint(1, null, "test", "test", "test", 1, 2, 0, CheckpointStatus.Active);
                 var subscription = new Subscription("test")
                 {
                     HandlerDelegate = async (IReadOnlyList<IMessageContext> _, CancellationToken ct) =>
@@ -273,7 +272,7 @@ public class CheckpointProcessorTests
             [Fact]
             public async Task throws_timeout_exception()
             {
-                var checkpoint = new Checkpoint(1, "test", "test", "test", 1, 2, 0, CheckpointStatus.Active);
+                var checkpoint = new Checkpoint(1, null, "test", "test", "test", 1, 2, 0, CheckpointStatus.Active);
                 var subscription = new Subscription("test")
                 {
                     HandlerDelegate = (IReadOnlyList<IMessageContext> _, CancellationToken ct) =>
@@ -311,7 +310,7 @@ public class CheckpointProcessorTests
             [Fact]
             public async Task throws_operation_canceled_exception()
             {
-                var checkpoint = new Checkpoint(1, "test", "test", "test", 1, 2, 0, CheckpointStatus.Active);
+                var checkpoint = new Checkpoint(1, null, "test", "test", "test", 1, 2, 0, CheckpointStatus.Active);
                 var subscription = new Subscription("test")
                 {
                     HandlerDelegate = (IReadOnlyList<IMessageContext> _, CancellationToken ct) =>
@@ -348,7 +347,7 @@ public class CheckpointProcessorTests
                 [Fact]
                 public async Task only_reads_messages_up_to_stream_version()
                 {
-                    var checkpoint = new Checkpoint(1, "test", "test", "test", 1, 10, 0, CheckpointStatus.Retry);
+                    var checkpoint = new Checkpoint(1, null, "test", "test", "test", 1, 10, 0, CheckpointStatus.Retry);
                     var subscription = new Subscription("test")
                     {
                         HandlerDelegate = (IReadOnlyList<IMessageContext> _) => { }
@@ -380,7 +379,7 @@ public class CheckpointProcessorTests
                 [Fact]
                 public async Task only_reads_messages_up_to_batch_size()
                 {
-                    var checkpoint = new Checkpoint(1, "test", "test", "test", 1, 20, 0, CheckpointStatus.Retry);
+                    var checkpoint = new Checkpoint(1, null, "test", "test", "test", 1, 20, 0, CheckpointStatus.Retry);
                     var subscription = new Subscription("test")
                     {
                         HandlerDelegate = (IReadOnlyList<IMessageContext> _) => { }
@@ -437,10 +436,19 @@ public class CheckpointProcessorTests
     )
     {
         database ??= Substitute.For<IPostgresDatabase>();
+        var dataSource = Substitute.For<IPostgresDataSource>();
         var serviceProvider = new ServiceCollection().BuildServiceProvider();
         var instrumentation = Substitute.For<IInstrumentation>();
         var logger = Substitute.For<ILogger<CheckpointProcessor>>();
 
-        return new CheckpointProcessor(messageStorage, database, serviceProvider, options, instrumentation, logger);
+        return new CheckpointProcessor(
+            messageStorage,
+            dataSource,
+            database,
+            serviceProvider,
+            options,
+            instrumentation,
+            logger
+        );
     }
 }

--- a/src/Beckett/Database/NpgsqlDataSourceBuilderExtensions.cs
+++ b/src/Beckett/Database/NpgsqlDataSourceBuilderExtensions.cs
@@ -12,6 +12,7 @@ public static class NpgsqlDataSourceBuilderExtensions
     )
     {
         builder.MapComposite<CheckpointType>(DataTypeNames.Checkpoint(schema));
+        builder.MapComposite<CheckpointStreamRetryType>(DataTypeNames.CheckpointStreamRetry(schema));
         builder.MapComposite<MessageType>(DataTypeNames.Message(schema));
         builder.MapComposite<RetryType>(DataTypeNames.Retry(schema));
         builder.MapComposite<ScheduledMessageType>(DataTypeNames.ScheduledMessage(schema));

--- a/src/Beckett/Database/Types/CheckpointStreamRetryType.cs
+++ b/src/Beckett/Database/Types/CheckpointStreamRetryType.cs
@@ -1,0 +1,24 @@
+using System.Text.Json;
+using Beckett.Subscriptions;
+using Beckett.Subscriptions.Retries;
+
+namespace Beckett.Database.Types;
+
+public class CheckpointStreamRetryType
+{
+    public string StreamName { get; init; } = null!;
+    public long StreamVersion { get; init; }
+    public long StreamPosition { get; init; }
+    public JsonElement Error { get; init; }
+
+    public static CheckpointStreamRetryType From(CheckpointStreamError streamError)
+    {
+        return new CheckpointStreamRetryType
+        {
+            StreamName = streamError.StreamName,
+            StreamVersion = streamError.StreamPosition,
+            StreamPosition = streamError.StreamPosition > 0 ? streamError.StreamPosition - 1 : 0,
+            Error = ExceptionData.From(streamError.Exception).ToJson().RootElement
+        };
+    }
+}

--- a/src/Beckett/Database/Types/DataTypeNames.cs
+++ b/src/Beckett/Database/Types/DataTypeNames.cs
@@ -8,6 +8,10 @@ public static class DataTypeNames
 
     public static string CheckpointArray(string schema) => $"{schema}.checkpoint[]";
 
+    public static string CheckpointStreamRetry(string schema) => $"{schema}.checkpoint_stream_retry";
+
+    public static string CheckpointStreamRetryArray(string schema) => $"{schema}.checkpoint_stream_retry[]";
+
     public static string Message(string schema) => $"{schema}.message";
 
     public static string MessageArray(string schema) => $"{schema}.message[]";

--- a/src/Beckett/ICheckpointContext.cs
+++ b/src/Beckett/ICheckpointContext.cs
@@ -1,0 +1,40 @@
+namespace Beckett;
+
+public interface ICheckpointContext
+{
+    /// <summary>
+    /// The checkpoint ID
+    /// </summary>
+    long Id { get; }
+
+    /// <summary>
+    /// Parent ID of the checkpoint. One use case for child checkpoints is when a subscription is global scoped but
+    /// manages retries and failures per-stream.
+    /// </summary>
+    long? ParentId { get; }
+
+    /// <summary>
+    /// Subscription group name for the checkpoint
+    /// </summary>
+    string GroupName { get; }
+
+    /// <summary>
+    /// Subscription name for the checkpoint
+    /// </summary>
+    string SubscriptionName { get; }
+
+    /// <summary>
+    /// Stream name of the checkpoint
+    /// </summary>
+    string StreamName { get; }
+
+    /// <summary>
+    /// The current version of the stream the checkpoint is tracking.
+    /// </summary>
+    long StreamVersion { get; }
+
+    /// <summary>
+    /// The current position of the checkpoint within the stream it is tracking.
+    /// </summary>
+    long StreamPosition { get; }
+}

--- a/src/Beckett/MessageStorage/Postgres/Queries/ReadStream.cs
+++ b/src/Beckett/MessageStorage/Postgres/Queries/ReadStream.cs
@@ -26,7 +26,7 @@ public class ReadStream(
                    data,
                    metadata,
                    timestamp
-            from {postgresOptions.Schema}.read_stream($1, $2, $3, $4, $5, $6, $7);
+            from {postgresOptions.Schema}.read_stream($1, $2, $3, $4, $5, $6, $7, $8);
         ";
 
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });

--- a/src/Beckett/Subscriptions/CheckpointContext.cs
+++ b/src/Beckett/Subscriptions/CheckpointContext.cs
@@ -1,0 +1,22 @@
+namespace Beckett.Subscriptions;
+
+public record CheckpointContext(
+    long Id,
+    long? ParentId,
+    string GroupName,
+    string SubscriptionName,
+    string StreamName,
+    long StreamVersion,
+    long StreamPosition
+) : ICheckpointContext
+{
+    public static ICheckpointContext Empty = new CheckpointContext(
+        0,
+        null,
+        string.Empty,
+        string.Empty,
+        string.Empty,
+        0,
+        0
+    );
+}

--- a/src/Beckett/Subscriptions/CheckpointStreamManager.cs
+++ b/src/Beckett/Subscriptions/CheckpointStreamManager.cs
@@ -1,0 +1,36 @@
+using Beckett.Database;
+using Beckett.Database.Types;
+using Beckett.Subscriptions.Queries;
+
+namespace Beckett.Subscriptions;
+
+public class CheckpointStreamManager(IPostgresDatabase database, PostgresOptions options) : ICheckpointStreamManager
+{
+    public async Task<IReadOnlyList<string>> GetBlockedStreams(
+        long checkpointId,
+        string[] streamNames,
+        CancellationToken cancellationToken
+    )
+    {
+        return await database.Execute(
+            new GetCheckpointBlockedStreams(checkpointId, streamNames, options),
+            cancellationToken
+        );
+    }
+
+    public async Task RetryStreamErrors(
+        long checkpointId,
+        IEnumerable<CheckpointStreamError> streamErrors,
+        CancellationToken cancellationToken
+    )
+    {
+        var retries = streamErrors.Select(CheckpointStreamRetryType.From).ToArray();
+
+        if (retries.Length == 0)
+        {
+            return;
+        }
+
+        await database.Execute(new RecordCheckpointStreamRetries(checkpointId, retries, options), cancellationToken);
+    }
+}

--- a/src/Beckett/Subscriptions/ICheckpointStreamManager.cs
+++ b/src/Beckett/Subscriptions/ICheckpointStreamManager.cs
@@ -1,0 +1,33 @@
+namespace Beckett.Subscriptions;
+
+public interface ICheckpointStreamManager
+{
+    /// <summary>
+    /// Get child checkpoint streams that are either retrying or failed for the given checkpoint ID and stream names.
+    /// </summary>
+    /// <param name="checkpointId"></param>
+    /// <param name="streamNames"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task<IReadOnlyList<string>> GetBlockedStreams(
+        long checkpointId,
+        string[] streamNames,
+        CancellationToken cancellationToken
+    );
+
+    /// <summary>
+    /// Create child checkpoints to allow individual streams to be retried and the parent checkpoint to continue
+    /// processing.
+    /// </summary>
+    /// <param name="checkpointId"></param>
+    /// <param name="streamErrors"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task RetryStreamErrors(
+        long checkpointId,
+        IEnumerable<CheckpointStreamError> streamErrors,
+        CancellationToken cancellationToken
+    );
+}
+
+public record CheckpointStreamError(string StreamName, long StreamPosition, Exception Exception);

--- a/src/Beckett/Subscriptions/Queries/GetCheckpointBlockedStreams.cs
+++ b/src/Beckett/Subscriptions/Queries/GetCheckpointBlockedStreams.cs
@@ -1,0 +1,39 @@
+using Beckett.Database;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace Beckett.Subscriptions.Queries;
+
+public class GetCheckpointBlockedStreams(
+    long checkpointId,
+    string[] streamNames,
+    PostgresOptions options
+) : IPostgresDatabaseQuery<IReadOnlyList<string>>
+{
+    public async Task<IReadOnlyList<string>> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
+    {
+        command.CommandText = $"select stream_name from {options.Schema}.get_checkpoint_blocked_streams($1, $2);";
+
+        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Bigint });
+        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Array | NpgsqlDbType.Text });
+
+        if (options.PrepareStatements)
+        {
+            await command.PrepareAsync(cancellationToken);
+        }
+
+        command.Parameters[0].Value = checkpointId;
+        command.Parameters[1].Value = streamNames;
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+
+        var streams = new List<string>();
+
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            streams.Add(reader.GetFieldValue<string>(0));
+        }
+
+        return streams;
+    }
+}

--- a/src/Beckett/Subscriptions/Queries/RecordCheckpointStreamRetries.cs
+++ b/src/Beckett/Subscriptions/Queries/RecordCheckpointStreamRetries.cs
@@ -1,0 +1,33 @@
+using Beckett.Database;
+using Beckett.Database.Types;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace Beckett.Subscriptions.Queries;
+
+public class RecordCheckpointStreamRetries(
+    long checkpointId,
+    CheckpointStreamRetryType[] retries,
+    PostgresOptions options
+) : IPostgresDatabaseQuery<int>
+{
+    public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
+    {
+        command.CommandText = $"select {options.Schema}.record_checkpoint_stream_retries($1, $2);";
+
+        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Bigint });
+        command.Parameters.Add(
+            new NpgsqlParameter { DataTypeName = DataTypeNames.CheckpointStreamRetryArray(options.Schema) }
+        );
+
+        if (options.PrepareStatements)
+        {
+            await command.PrepareAsync(cancellationToken);
+        }
+
+        command.Parameters[0].Value = checkpointId;
+        command.Parameters[1].Value = retries;
+
+        return await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+}

--- a/src/Beckett/Subscriptions/Queries/ReserveCheckpoint.cs
+++ b/src/Beckett/Subscriptions/Queries/ReserveCheckpoint.cs
@@ -1,0 +1,37 @@
+using Beckett.Database;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace Beckett.Subscriptions.Queries;
+
+public class ReserveCheckpoint(
+    long id,
+    TimeSpan reservationTimeout,
+    PostgresOptions options
+) : IPostgresDatabaseQuery<long?>
+{
+    public async Task<long?> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
+    {
+        command.CommandText = $"select {options.Schema}.reserve_checkpoint($1, $2);";
+
+        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Bigint });
+        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Interval });
+
+        if (options.PrepareStatements)
+        {
+            await command.PrepareAsync(cancellationToken);
+        }
+
+        command.Parameters[0].Value = id;
+        command.Parameters[1].Value = reservationTimeout;
+
+        var result = await command.ExecuteScalarAsync(cancellationToken);
+
+        return result switch
+        {
+            long streamVersion => streamVersion,
+            DBNull => null,
+            _ => throw new Exception($"Unexpected result from reserve_checkpoint function: {result}")
+        };
+    }
+}

--- a/src/Beckett/Subscriptions/Queries/ReserveNextAvailableCheckpoint.cs
+++ b/src/Beckett/Subscriptions/Queries/ReserveNextAvailableCheckpoint.cs
@@ -13,7 +13,7 @@ public class ReserveNextAvailableCheckpoint(
     public async Task<Checkpoint?> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
         command.CommandText = $@"
-            select id, group_name, name, stream_name, stream_position, stream_version, retry_attempts, status
+            select id, parent_id, group_name, name, stream_name, stream_position, stream_version, retry_attempts, status
             from {options.Schema}.reserve_next_available_checkpoint($1, $2);
         ";
 

--- a/src/Beckett/Subscriptions/Queries/UpdateChildCheckpointPosition.cs
+++ b/src/Beckett/Subscriptions/Queries/UpdateChildCheckpointPosition.cs
@@ -1,0 +1,36 @@
+using Beckett.Database;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace Beckett.Subscriptions.Queries;
+
+public class UpdateChildCheckpointPosition(
+    long id,
+    long streamPosition,
+    long? streamVersion,
+    DateTimeOffset? processAt,
+    PostgresOptions options
+) : IPostgresDatabaseQuery<int>
+{
+    public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
+    {
+        command.CommandText = $"select {options.Schema}.update_child_checkpoint_position($1, $2, $3, $4);";
+
+        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Bigint });
+        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Bigint });
+        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Bigint, IsNullable = true });
+        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.TimestampTz, IsNullable = true });
+
+        if (options.PrepareStatements)
+        {
+            await command.PrepareAsync(cancellationToken);
+        }
+
+        command.Parameters[0].Value = id;
+        command.Parameters[1].Value = streamPosition;
+        command.Parameters[2].Value = streamVersion.HasValue ? streamVersion.Value : DBNull.Value;
+        command.Parameters[3].Value = processAt.HasValue ? processAt.Value : DBNull.Value;
+
+        return await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+}

--- a/src/Beckett/Subscriptions/ServiceCollectionExtensions.cs
+++ b/src/Beckett/Subscriptions/ServiceCollectionExtensions.cs
@@ -23,6 +23,8 @@ public static class ServiceCollectionExtensions
 
         services.AddSingleton<ICheckpointConsumerGroup, CheckpointConsumerGroup>();
 
+        services.AddSingleton<ICheckpointStreamManager, CheckpointStreamManager>();
+
         services.AddSingleton<IPostgresNotificationHandler, CheckpointNotificationHandler>();
 
         services.AddSingleton<IPostgresNotificationHandler, MessageNotificationHandler>();


### PR DESCRIPTION
Adds the ability to have individual streams retry/fail for a global-scoped subscription. Using the new `ICheckpointContext` and injecting `ICheckpointStreamManager` a global-scoped subscription has the ability to check for blocked streams and record new retries as necessary. Beckett then processes these as normal stream-scoped checkpoints, up until the checkpoint is successfully processed. At that point the stream checkpoint will rejoin the the global subscription and be removed, with Beckett handling the necessary steps to synchronize and safely do the handover so no messages are missed.