### PR TITLE
Checkpoint Processing Improvements

### DIFF
--- a/samples/TaskHub/Worker/Program.cs
+++ b/samples/TaskHub/Worker/Program.cs
@@ -19,12 +19,21 @@ try
 
     builder.Services.AddSerilog((_, configuration) => configuration.ReadFrom.Configuration(builder.Configuration));
 
+    //default host shutdown timeout is 30 seconds - make sure that it's set higher than your reservation timeout
+    builder.Services.Configure<HostOptions>(options => options.ShutdownTimeout = TimeSpan.FromSeconds(90));
+
     await builder.AddTaskHubDatabase();
 
     builder.Services.ConfigureServices();
 
     builder.Services.AddBeckett(
-        options => { options.WithSubscriptionGroup("TaskHub"); }
+        options =>
+        {
+            options.WithSubscriptionGroup("TaskHub");
+
+            //default reservation timeout is 5 minutes - we can lower that for the purposes of this demo
+            options.Subscriptions.ReservationTimeout = TimeSpan.FromSeconds(60);
+        }
     ).WithSubscriptionsFrom(TaskHubAssembly.Instance);
 
     builder.Services.AddOpenTelemetry()

--- a/src/Beckett.Tests/Subscriptions/CheckpointProcessorTests.cs
+++ b/src/Beckett.Tests/Subscriptions/CheckpointProcessorTests.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Beckett.Database;
 using Beckett.Messages;
 using Beckett.MessageStorage;
@@ -37,7 +36,7 @@ public class CheckpointProcessorTests
                 var messageStorage = Substitute.For<IMessageStorage>();
                 var checkpointProcessor = BuildCheckpointProcessor(options, messageStorage);
 
-                await checkpointProcessor.Process(1, checkpoint, subscription, CancellationToken.None);
+                await checkpointProcessor.Process(1, checkpoint, subscription);
 
                 await messageStorage.Received().ReadStream(
                     "test",
@@ -69,7 +68,7 @@ public class CheckpointProcessorTests
                 var messageStorage = Substitute.For<IMessageStorage>();
                 var checkpointProcessor = BuildCheckpointProcessor(options, messageStorage);
 
-                await checkpointProcessor.Process(1, checkpoint, subscription, CancellationToken.None);
+                await checkpointProcessor.Process(1, checkpoint, subscription);
 
                 await messageStorage.Received().ReadStream(
                     "test",
@@ -113,7 +112,7 @@ public class CheckpointProcessorTests
                 database.WhenForAnyArgs(x => x.Execute(Arg.Any<RecordCheckpointError>(), Arg.Any<CancellationToken>()))
                     .Do(x => error = x.Arg<RecordCheckpointError>());
 
-                await checkpointProcessor.Process(1, checkpoint, subscription, CancellationToken.None);
+                await checkpointProcessor.Process(1, checkpoint, subscription);
 
                 Assert.NotNull(error);
                 Assert.True(IsTimeoutException(error));
@@ -151,47 +150,10 @@ public class CheckpointProcessorTests
                 database.WhenForAnyArgs(x => x.Execute(Arg.Any<RecordCheckpointError>(), Arg.Any<CancellationToken>()))
                     .Do(x => error = x.Arg<RecordCheckpointError>());
 
-                await checkpointProcessor.Process(1, checkpoint, subscription, CancellationToken.None);
+                await checkpointProcessor.Process(1, checkpoint, subscription);
 
                 Assert.NotNull(error);
                 Assert.True(IsTimeoutException(error));
-            }
-        }
-
-        public class when_the_stopping_token_is_cancelled
-        {
-            [Fact]
-            public async Task throws_operation_canceled_exception()
-            {
-                var checkpoint = new Checkpoint(1, "test", "test", "test", 1, 2, 0, CheckpointStatus.Active);
-                var subscription = new Subscription("test")
-                {
-                    HandlerDelegate = async (IMessageContext _, CancellationToken ct) =>
-                    {
-                        await Task.Delay(TimeSpan.FromMilliseconds(5), ct);
-                    }
-                };
-                subscription.RegisterMessageType<TestMessage>();
-                subscription.BuildHandler();
-                var options = new BeckettOptions
-                {
-                    Subscriptions =
-                    {
-                        ReservationTimeout = TimeSpan.FromMilliseconds(1)
-                    }
-                };
-                var messageStorage = Substitute.For<IMessageStorage>();
-                var checkpointProcessor = BuildCheckpointProcessor(options, messageStorage);
-                var parentCts = new CancellationTokenSource();
-                var innerCts = CancellationTokenSource.CreateLinkedTokenSource(parentCts.Token);
-
-                messageStorage.ReadStream("test", Arg.Any<ReadStreamOptions>(), Arg.Any<CancellationToken>())
-                    .Returns(new ReadStreamResult("test", 2, [BuildStreamMessage()]));
-                await parentCts.CancelAsync();
-
-                await Assert.ThrowsAsync<OperationCanceledException>(
-                    () => checkpointProcessor.Process(1, checkpoint, subscription, innerCts.Token)
-                );
             }
         }
 
@@ -217,7 +179,7 @@ public class CheckpointProcessorTests
                 var messageStorage = Substitute.For<IMessageStorage>();
                 var checkpointProcessor = BuildCheckpointProcessor(options, messageStorage);
 
-                await checkpointProcessor.Process(1, checkpoint, subscription, CancellationToken.None);
+                await checkpointProcessor.Process(1, checkpoint, subscription);
 
                 await messageStorage.Received().ReadStream(
                     "test",
@@ -261,7 +223,7 @@ public class CheckpointProcessorTests
                 database.WhenForAnyArgs(x => x.Execute(Arg.Any<RecordCheckpointError>(), Arg.Any<CancellationToken>()))
                     .Do(x => error = x.Arg<RecordCheckpointError>());
 
-                await checkpointProcessor.Process(1, checkpoint, subscription, CancellationToken.None);
+                await checkpointProcessor.Process(1, checkpoint, subscription);
 
                 Assert.NotNull(error);
                 Assert.True(IsTimeoutException(error));
@@ -299,45 +261,10 @@ public class CheckpointProcessorTests
                 database.WhenForAnyArgs(x => x.Execute(Arg.Any<RecordCheckpointError>(), Arg.Any<CancellationToken>()))
                     .Do(x => error = x.Arg<RecordCheckpointError>());
 
-                await checkpointProcessor.Process(1, checkpoint, subscription, CancellationToken.None);
+                await checkpointProcessor.Process(1, checkpoint, subscription);
 
                 Assert.NotNull(error);
                 Assert.True(IsTimeoutException(error));
-            }
-        }
-
-        public class when_the_stopping_token_is_cancelled
-        {
-            [Fact]
-            public async Task throws_operation_canceled_exception()
-            {
-                var checkpoint = new Checkpoint(1, "test", "test", "test", 1, 2, 0, CheckpointStatus.Active);
-                var subscription = new Subscription("test")
-                {
-                    HandlerDelegate = (IReadOnlyList<IMessageContext> _, CancellationToken ct) =>
-                        Task.Delay(TimeSpan.FromMilliseconds(2), ct)
-                };
-                subscription.RegisterMessageType<TestMessage>();
-                subscription.BuildHandler();
-                var options = new BeckettOptions
-                {
-                    Subscriptions =
-                    {
-                        ReservationTimeout = TimeSpan.FromMilliseconds(1)
-                    }
-                };
-                var messageStorage = Substitute.For<IMessageStorage>();
-                var checkpointProcessor = BuildCheckpointProcessor(options, messageStorage);
-                var parentCts = new CancellationTokenSource();
-                var innerCts = CancellationTokenSource.CreateLinkedTokenSource(parentCts.Token);
-
-                messageStorage.ReadStream("test", Arg.Any<ReadStreamOptions>(), Arg.Any<CancellationToken>())
-                    .Returns(new ReadStreamResult("test", 2, [BuildStreamMessage()]));
-                await parentCts.CancelAsync();
-
-                await Assert.ThrowsAsync<OperationCanceledException>(
-                    () => checkpointProcessor.Process(1, checkpoint, subscription, innerCts.Token)
-                );
             }
         }
 
@@ -365,7 +292,7 @@ public class CheckpointProcessorTests
                     var messageStorage = Substitute.For<IMessageStorage>();
                     var checkpointProcessor = BuildCheckpointProcessor(options, messageStorage);
 
-                    await checkpointProcessor.Process(1, checkpoint, subscription, CancellationToken.None);
+                    await checkpointProcessor.Process(1, checkpoint, subscription);
 
                     await messageStorage.Received().ReadStream(
                         "test",
@@ -397,7 +324,7 @@ public class CheckpointProcessorTests
                     var messageStorage = Substitute.For<IMessageStorage>();
                     var checkpointProcessor = BuildCheckpointProcessor(options, messageStorage);
 
-                    await checkpointProcessor.Process(1, checkpoint, subscription, CancellationToken.None);
+                    await checkpointProcessor.Process(1, checkpoint, subscription);
 
                     await messageStorage.Received().ReadStream(
                         "test",

--- a/src/Beckett/Dashboard/Postgres/Services/RefreshTenantMaterializedView.cs
+++ b/src/Beckett/Dashboard/Postgres/Services/RefreshTenantMaterializedView.cs
@@ -14,17 +14,15 @@ public class RefreshTenantMaterializedView(
     {
         await Task.Yield();
 
-        while (true)
+        var timer = new PeriodicTimer(options.TenantRefreshInterval);
+
+        while (await timer.WaitForNextTickAsync(stoppingToken))
         {
             try
             {
-                stoppingToken.ThrowIfCancellationRequested();
-
                 await dashboard.MessageStore.RefreshTenants(stoppingToken);
-
-                await Task.Delay(options.TenantRefreshInterval, stoppingToken);
             }
-            catch (OperationCanceledException e) when (e.CancellationToken == stoppingToken)
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {
                 throw;
             }

--- a/src/Beckett/Database/Notifications/IPostgresNotificationListener.cs
+++ b/src/Beckett/Database/Notifications/IPostgresNotificationListener.cs
@@ -2,5 +2,5 @@ namespace Beckett.Database.Notifications;
 
 public interface IPostgresNotificationListener
 {
-    Task Listen(CancellationToken cancellationToken);
+    Task Listen(CancellationToken stoppingToken);
 }

--- a/src/Beckett/Subscriptions/ICheckpointConsumer.cs
+++ b/src/Beckett/Subscriptions/ICheckpointConsumer.cs
@@ -1,6 +1,0 @@
-namespace Beckett.Subscriptions;
-
-public interface ICheckpointConsumer
-{
-    Task StartPolling(CancellationToken cancellationToken);
-}

--- a/src/Beckett/Subscriptions/ICheckpointConsumerGroup.cs
+++ b/src/Beckett/Subscriptions/ICheckpointConsumerGroup.cs
@@ -2,7 +2,6 @@ namespace Beckett.Subscriptions;
 
 public interface ICheckpointConsumerGroup
 {
-    void Initialize(CancellationToken stoppingToken);
-
-    void StartPolling(string groupName);
+    void Notify(string groupName);
+    Task Poll(CancellationToken stoppingToken);
 }

--- a/src/Beckett/Subscriptions/ICheckpointProcessor.cs
+++ b/src/Beckett/Subscriptions/ICheckpointProcessor.cs
@@ -2,10 +2,5 @@ namespace Beckett.Subscriptions;
 
 public interface ICheckpointProcessor
 {
-    Task Process(
-        int instance,
-        Checkpoint checkpoint,
-        Subscription subscription,
-        CancellationToken cancellationToken
-    );
+    Task Process(int instance, Checkpoint checkpoint, Subscription subscription);
 }

--- a/src/Beckett/Subscriptions/IGlobalStreamConsumer.cs
+++ b/src/Beckett/Subscriptions/IGlobalStreamConsumer.cs
@@ -2,5 +2,6 @@ namespace Beckett.Subscriptions;
 
 public interface IGlobalStreamConsumer
 {
-    void StartPolling(CancellationToken stoppingToken);
+    void Notify();
+    Task Poll(CancellationToken stoppingToken);
 }

--- a/src/Beckett/Subscriptions/NotificationHandlers/CheckpointNotificationHandler.cs
+++ b/src/Beckett/Subscriptions/NotificationHandlers/CheckpointNotificationHandler.cs
@@ -16,7 +16,7 @@ public class CheckpointNotificationHandler(
         {
             logger.StartingCheckpointNotificationPolling();
 
-            checkpointConsumerGroup.StartPolling(payload);
+            checkpointConsumerGroup.Notify(payload);
         }
         catch (Exception e)
         {

--- a/src/Beckett/Subscriptions/NotificationHandlers/MessageNotificationHandler.cs
+++ b/src/Beckett/Subscriptions/NotificationHandlers/MessageNotificationHandler.cs
@@ -16,7 +16,7 @@ public class MessageNotificationHandler(
         {
             logger.StartingGlobalStreamNotificationPolling();
 
-            globalStreamConsumer.StartPolling(cancellationToken);
+            globalStreamConsumer.Notify();
         }
         catch (Exception e)
         {

--- a/src/Beckett/Subscriptions/ServiceCollectionExtensions.cs
+++ b/src/Beckett/Subscriptions/ServiceCollectionExtensions.cs
@@ -34,7 +34,11 @@ public static class ServiceCollectionExtensions
 
         services.AddHostedService<BootstrapSubscriptions>();
 
+        services.AddHostedService<GlobalStreamConsumerHost>();
+
         services.AddHostedService<GlobalStreamPollingService>();
+
+        services.AddHostedService<CheckpointConsumerGroupHost>();
 
         services.AddHostedService<CheckpointPollingService>();
 

--- a/src/Beckett/Subscriptions/Services/BootstrapSubscriptions.cs
+++ b/src/Beckett/Subscriptions/Services/BootstrapSubscriptions.cs
@@ -15,122 +15,66 @@ public class BootstrapSubscriptions(
     ILogger<BootstrapSubscriptions> logger
 ) : IHostedService
 {
-    public async Task StartAsync(CancellationToken cancellationToken)
+    public async Task StartAsync(CancellationToken stoppingToken)
     {
-        try
+        await using var connection = dataSource.CreateConnection();
+
+        await connection.OpenAsync(stoppingToken);
+
+        await using var transaction = await connection.BeginTransactionAsync(stoppingToken);
+
+        var globalPosition = await database.Execute(
+            new EnsureCheckpointExists(
+                options.Subscriptions.GroupName,
+                GlobalCheckpoint.Name,
+                GlobalCheckpoint.StreamName,
+                options.Postgres
+            ),
+            connection,
+            transaction,
+            stoppingToken
+        );
+
+        var checkpoints = new List<CheckpointType>();
+
+        foreach (var subscription in SubscriptionRegistry.All())
         {
-            await using var connection = dataSource.CreateConnection();
+            subscription.BuildHandler();
 
-            await connection.OpenAsync(cancellationToken);
+            logger.LogTrace(
+                "Adding or updating subscription {Name} in group {GroupName}",
+                subscription.Name,
+                options.Subscriptions.GroupName
+            );
 
-            await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
-
-            var globalPosition = await database.Execute(
-                new EnsureCheckpointExists(
+            var status = await database.Execute(
+                new AddOrUpdateSubscription(
                     options.Subscriptions.GroupName,
-                    GlobalCheckpoint.Name,
-                    GlobalCheckpoint.StreamName,
+                    subscription.Name,
                     options.Postgres
                 ),
                 connection,
                 transaction,
-                cancellationToken
+                stoppingToken
             );
 
-            var checkpoints = new List<CheckpointType>();
-
-            foreach (var subscription in SubscriptionRegistry.All())
+            if (status == SubscriptionStatus.Active)
             {
-                subscription.BuildHandler();
-
                 logger.LogTrace(
-                    "Adding or updating subscription {Name} in group {GroupName}",
+                    "Subscription {Name} in group {GroupName} is already active - no need for further action.",
                     subscription.Name,
                     options.Subscriptions.GroupName
                 );
 
-                var status = await database.Execute(
-                    new AddOrUpdateSubscription(
-                        options.Subscriptions.GroupName,
-                        subscription.Name,
-                        options.Postgres
-                    ),
-                    connection,
-                    transaction,
-                    cancellationToken
-                );
+                continue;
+            }
 
-                if (status == SubscriptionStatus.Active)
-                {
-                    logger.LogTrace(
-                        "Subscription {Name} in group {GroupName} is already active - no need for further action.",
-                        subscription.Name,
-                        options.Subscriptions.GroupName
-                    );
-
-                    continue;
-                }
-
-                if (subscription.StreamScope == StreamScope.GlobalStream)
-                {
-                    logger.LogTrace(
-                        "Subscription {Name} in group {GroupName} is scoped to the global stream so it will be set to active and will start processing messages from the beginning of the global stream.",
-                        subscription.Name,
-                        options.Subscriptions.GroupName
-                    );
-
-                    checkpoints.Add(
-                        new CheckpointType
-                        {
-                            GroupName = options.Subscriptions.GroupName,
-                            Name = subscription.Name,
-                            StreamName = GlobalStream.Name,
-                            StreamVersion = globalPosition
-                        }
-                    );
-
-                    await database.Execute(
-                        new SetSubscriptionToActive(
-                            options.Subscriptions.GroupName,
-                            subscription.Name,
-                            options.Postgres
-                        ),
-                        connection,
-                        transaction,
-                        cancellationToken
-                    );
-
-                    continue;
-                }
-
-                if (subscription.StartingPosition == StartingPosition.Latest)
-                {
-                    logger.LogTrace(
-                        "Subscription {Name} in group {GroupName} has a starting position of {StartingPosition} so it will be set to active and will start processing new messages going forward.",
-                        subscription.Name,
-                        options.Subscriptions.GroupName,
-                        subscription.StartingPosition
-                    );
-
-                    await database.Execute(
-                        new SetSubscriptionToActive(
-                            options.Subscriptions.GroupName,
-                            subscription.Name,
-                            options.Postgres
-                        ),
-                        connection,
-                        transaction,
-                        cancellationToken
-                    );
-
-                    continue;
-                }
-
+            if (subscription.StreamScope == StreamScope.GlobalStream)
+            {
                 logger.LogTrace(
-                    "Subscription {Name} in group {GroupName} has a starting position of {StartingPosition} so it will need to be initialized before it can start processing new messages.",
+                    "Subscription {Name} in group {GroupName} is scoped to the global stream so it will be set to active and will start processing messages from the beginning of the global stream.",
                     subscription.Name,
-                    options.Subscriptions.GroupName,
-                    subscription.StartingPosition
+                    options.Subscriptions.GroupName
                 );
 
                 checkpoints.Add(
@@ -138,40 +82,89 @@ public class BootstrapSubscriptions(
                     {
                         GroupName = options.Subscriptions.GroupName,
                         Name = subscription.Name,
-                        StreamName = InitializationConstants.StreamName,
-                        StreamVersion = 0
+                        StreamName = GlobalStream.Name,
+                        StreamVersion = globalPosition
                     }
                 );
-            }
 
-            if (checkpoints.Count > 0)
-            {
                 await database.Execute(
-                    new RecordCheckpoints(checkpoints.ToArray(), options.Postgres),
+                    new SetSubscriptionToActive(
+                        options.Subscriptions.GroupName,
+                        subscription.Name,
+                        options.Postgres
+                    ),
                     connection,
                     transaction,
-                    cancellationToken
+                    stoppingToken
                 );
+
+                continue;
             }
 
-            await transaction.CommitAsync(cancellationToken);
-
-            if (options.Subscriptions.InitializationConcurrency <= 0)
+            if (subscription.StartingPosition == StartingPosition.Latest)
             {
-                return;
+                logger.LogTrace(
+                    "Subscription {Name} in group {GroupName} has a starting position of {StartingPosition} so it will be set to active and will start processing new messages going forward.",
+                    subscription.Name,
+                    options.Subscriptions.GroupName,
+                    subscription.StartingPosition
+                );
+
+                await database.Execute(
+                    new SetSubscriptionToActive(
+                        options.Subscriptions.GroupName,
+                        subscription.Name,
+                        options.Postgres
+                    ),
+                    connection,
+                    transaction,
+                    stoppingToken
+                );
+
+                continue;
             }
 
-            await Task.Yield();
+            logger.LogTrace(
+                "Subscription {Name} in group {GroupName} has a starting position of {StartingPosition} so it will need to be initialized before it can start processing new messages.",
+                subscription.Name,
+                options.Subscriptions.GroupName,
+                subscription.StartingPosition
+            );
 
-            var initializationTasks = Enumerable.Range(1, options.Subscriptions.InitializationConcurrency)
-                .Select(_ => subscriptionInitializer.Initialize(cancellationToken)).ToArray();
-
-            await Task.WhenAll(initializationTasks);
+            checkpoints.Add(
+                new CheckpointType
+                {
+                    GroupName = options.Subscriptions.GroupName,
+                    Name = subscription.Name,
+                    StreamName = InitializationConstants.StreamName,
+                    StreamVersion = 0
+                }
+            );
         }
-        catch (OperationCanceledException e) when (e.CancellationToken.IsCancellationRequested)
+
+        if (checkpoints.Count > 0)
         {
-            // do nothing
+            await database.Execute(
+                new RecordCheckpoints(checkpoints.ToArray(), options.Postgres),
+                connection,
+                transaction,
+                stoppingToken
+            );
         }
+
+        await transaction.CommitAsync(stoppingToken);
+
+        if (options.Subscriptions.InitializationConcurrency <= 0)
+        {
+            return;
+        }
+
+        await Task.Yield();
+
+        var initializationTasks = Enumerable.Range(1, options.Subscriptions.InitializationConcurrency)
+            .Select(_ => subscriptionInitializer.Initialize(stoppingToken)).ToArray();
+
+        await Task.WhenAll(initializationTasks);
     }
 
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;

--- a/src/Beckett/Subscriptions/Services/CheckpointConsumerGroupHost.cs
+++ b/src/Beckett/Subscriptions/Services/CheckpointConsumerGroupHost.cs
@@ -1,0 +1,11 @@
+using Microsoft.Extensions.Hosting;
+
+namespace Beckett.Subscriptions.Services;
+
+public class CheckpointConsumerGroupHost(ICheckpointConsumerGroup consumerGroup) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await consumerGroup.Poll(stoppingToken);
+    }
+}

--- a/src/Beckett/Subscriptions/Services/GlobalStreamConsumerHost.cs
+++ b/src/Beckett/Subscriptions/Services/GlobalStreamConsumerHost.cs
@@ -1,0 +1,11 @@
+using Microsoft.Extensions.Hosting;
+
+namespace Beckett.Subscriptions.Services;
+
+public class GlobalStreamConsumerHost(IGlobalStreamConsumer globalStreamConsumer) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await globalStreamConsumer.Poll(stoppingToken);
+    }
+}

--- a/src/Beckett/Subscriptions/Services/GlobalStreamPollingService.cs
+++ b/src/Beckett/Subscriptions/Services/GlobalStreamPollingService.cs
@@ -18,19 +18,17 @@ public class GlobalStreamPollingService(
             return;
         }
 
-        while (true)
+        var timer = new PeriodicTimer(options.GlobalStreamPollingInterval);
+
+        while (await timer.WaitForNextTickAsync(stoppingToken))
         {
             try
             {
-                stoppingToken.ThrowIfCancellationRequested();
-
                 logger.StartingGlobalStreamIntervalPolling();
 
-                globalStreamConsumer.StartPolling(stoppingToken);
-
-                await Task.Delay(options.GlobalStreamPollingInterval, stoppingToken);
+                globalStreamConsumer.Notify();
             }
-            catch (OperationCanceledException e) when (e.CancellationToken.IsCancellationRequested)
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {
                 throw;
             }

--- a/src/Beckett/Subscriptions/Services/RecoverExpiredCheckpointReservationsService.cs
+++ b/src/Beckett/Subscriptions/Services/RecoverExpiredCheckpointReservationsService.cs
@@ -37,7 +37,7 @@ public class RecoverExpiredCheckpointReservationsService(
                     logger.RecoveredExpiredCheckpointReservations(recovered);
                 }
             }
-            catch (OperationCanceledException e) when (e.CancellationToken.IsCancellationRequested)
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {
                 throw;
             }


### PR DESCRIPTION
- ensure that reserved checkpoints are processed prior to shutdown if possible
  - the driver here is frequent deployments leaving checkpoints in a stuck state and having to wait until their reservation time lapses after the host restarts in order to recover them - with this change Beckett will make a best effort to ensure the checkpoint finishes processing before shutdown. if the reservation or host shutdown timeout lapses before that however the service will stop and the checkpoint will need to be recovered later.
  - once a checkpoint is reserved the stopping token for the host is ignored so that processing can complete before it stops
  - the reservation timeout dictates how much time is allowed to process the checkpoint, as such the host shutdown timeout should be configured appropriately so that it's longer than the reservation timeout
- improved cancellation token handling
  - check that cancellation has been requested for specific tokens vs relying on the `CancellationToken` property of the `OperationCanceledException` which can be a different token than what you expect in various scenarios
- improved polling handling
  - host services for consumers to separate keep alive polling cycle from continuous polling loop
  - use channels to notify consumers that there is something for them to do