### PR TITLE
Stream data recording fix

### DIFF
--- a/db/migrations/001.sql
+++ b/db/migrations/001.sql
@@ -132,9 +132,7 @@ DECLARE
   _current_version bigint;
   _stream_version bigint;
 BEGIN
-  IF (_expected_version < 0) THEN
-    PERFORM pg_advisory_xact_lock(__schema__.stream_hash(_stream_name));
-  END IF;
+  PERFORM pg_advisory_xact_lock(__schema__.stream_hash(_stream_name));
 
   SELECT coalesce(max(m.stream_position), 0)
   INTO _current_version

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -136,9 +136,7 @@ DECLARE
   _current_version bigint;
   _stream_version bigint;
 BEGIN
-  IF (_expected_version < 0) THEN
-    PERFORM pg_advisory_xact_lock(beckett.stream_hash(_stream_name));
-  END IF;
+  PERFORM pg_advisory_xact_lock(beckett.stream_hash(_stream_name));
 
   SELECT coalesce(max(m.stream_position), 0)
   INTO _current_version

--- a/db/versions/0.18.1.sql
+++ b/db/versions/0.18.1.sql
@@ -1,0 +1,67 @@
+-- add back stream lock when appending messages
+CREATE OR REPLACE FUNCTION beckett.append_to_stream(
+  _stream_name text,
+  _expected_version bigint,
+  _messages beckett.message[]
+)
+  RETURNS bigint
+  LANGUAGE plpgsql
+AS
+$$
+DECLARE
+  _current_version bigint;
+  _stream_version bigint;
+BEGIN
+  PERFORM pg_advisory_xact_lock(beckett.stream_hash(_stream_name));
+
+  SELECT coalesce(max(m.stream_position), 0)
+  INTO _current_version
+  FROM beckett.messages m
+  WHERE m.stream_name = _stream_name
+  AND m.archived = false;
+
+  IF (_expected_version < -2) THEN
+    RAISE EXCEPTION 'Invalid value for expected version: %', _expected_version;
+  END IF;
+
+  IF (_expected_version = -1 AND _current_version = 0) THEN
+    RAISE EXCEPTION 'Attempted to append to a non-existing stream: %', _stream_name;
+  END IF;
+
+  IF (_expected_version = 0 AND _current_version > 0) THEN
+    RAISE EXCEPTION 'Attempted to start a stream that already exists: %', _stream_name;
+  END IF;
+
+  IF (_expected_version > 0 AND _expected_version != _current_version) THEN
+    RAISE EXCEPTION 'Stream % version % does not match expected version %',
+      _stream_name,
+      _current_version,
+      _expected_version;
+  END IF;
+
+  WITH append_messages AS (
+    INSERT INTO beckett.messages (
+      id,
+      stream_position,
+      stream_name,
+      type,
+      data,
+      metadata
+    )
+    SELECT m.id,
+           _current_version + (row_number() over())::bigint,
+           _stream_name,
+           m.type,
+           m.data,
+           m.metadata
+    FROM unnest(_messages) AS m
+    RETURNING stream_position, type
+  )
+  SELECT max(stream_position) INTO _stream_version
+  FROM append_messages;
+
+  PERFORM pg_notify('beckett:messages', NULL);
+
+  RETURN _stream_version;
+END;
+$$;

--- a/samples/Core/MessageHandling/ProcessorHandler.cs
+++ b/samples/Core/MessageHandling/ProcessorHandler.cs
@@ -17,8 +17,6 @@ public static class ProcessorHandler
         CancellationToken cancellationToken
     )
     {
-        Console.WriteLine($"MESSAGE: {context.Type}, lag: {DateTimeOffset.UtcNow.Subtract(context.Timestamp).TotalMilliseconds}ms");
-
         using var scope = serviceProvider.CreateScope();
 
         var handler = scope.ServiceProvider.GetRequiredService(messageHandlerType);

--- a/samples/TaskHub/API/V1/TaskLists/AddTaskEndpoint.cs
+++ b/samples/TaskHub/API/V1/TaskLists/AddTaskEndpoint.cs
@@ -22,6 +22,10 @@ public static class AddTaskEndpoint
         {
             return Results.Conflict();
         }
+        catch (ResourceAlreadyExistsException)
+        {
+            return Results.Conflict();
+        }
     }
 
     public record Request(string Task);

--- a/src/Beckett/OpenTelemetry/Instrumentation.cs
+++ b/src/Beckett/OpenTelemetry/Instrumentation.cs
@@ -148,7 +148,7 @@ public class Instrumentation : IInstrumentation, IDisposable
         );
 
         var activity = _activitySource.StartActivity(
-            $"{_options.Subscriptions.GroupName}.{subscription.Name}",
+            subscription.Name,
             ActivityKind.Internal,
             parentContext.ActivityContext
         );
@@ -160,7 +160,11 @@ public class Instrumentation : IInstrumentation, IDisposable
 
         activity.AddTag(TelemetryConstants.Subscription.GroupName, _options.Subscriptions.GroupName);
         activity.AddTag(TelemetryConstants.Subscription.Name, subscription.Name);
-        activity.AddTag(TelemetryConstants.Subscription.Category, subscription.Category);
+
+        if (!string.IsNullOrWhiteSpace(subscription.Category))
+        {
+            activity.AddTag(TelemetryConstants.Subscription.Category, subscription.Category);
+        }
 
         if (!string.IsNullOrWhiteSpace(subscription.HandlerName))
         {

--- a/src/Beckett/Subscriptions/ServiceCollectionExtensions.cs
+++ b/src/Beckett/Subscriptions/ServiceCollectionExtensions.cs
@@ -12,6 +12,11 @@ public static class ServiceCollectionExtensions
     {
         services.AddSingleton(options.Subscriptions);
 
+        if (!options.Subscriptions.Enabled)
+        {
+            return;
+        }
+
         services.AddSingleton<ISubscriptionInitializer, SubscriptionInitializer>();
 
         services.AddSingleton<IGlobalStreamConsumer, GlobalStreamConsumer>();
@@ -24,11 +29,6 @@ public static class ServiceCollectionExtensions
 
         services.AddSingleton<IPostgresNotificationHandler, MessageNotificationHandler>();
 
-        if (!options.Subscriptions.Enabled)
-        {
-            return;
-        }
-
         services.AddHostedService<BootstrapSubscriptions>();
 
         services.AddHostedService<GlobalStreamConsumerHost>();
@@ -38,6 +38,8 @@ public static class ServiceCollectionExtensions
         services.AddHostedService<CheckpointConsumerGroupHost>();
 
         services.AddHostedService<CheckpointPollingService>();
+
+        services.AddHostedService<StreamDataRecordingService>();
 
         services.AddHostedService<RecoverExpiredCheckpointReservationsService>();
     }

--- a/src/Beckett/Subscriptions/Services/StreamDataRecordingService.cs
+++ b/src/Beckett/Subscriptions/Services/StreamDataRecordingService.cs
@@ -1,0 +1,31 @@
+using Beckett.Database;
+using Beckett.Subscriptions.Queries;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Beckett.Subscriptions.Services;
+
+public class StreamDataRecordingService(
+    IPostgresDatabase database,
+    BeckettOptions options,
+    ILogger<StreamDataRecordingService> logger
+) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await foreach (var data in StreamDataQueue.Reader.ReadAllAsync(stoppingToken))
+        {
+            try
+            {
+                await database.Execute(
+                    new RecordStreamData(data.Categories, data.CategoryTimestamps, data.Tenants, options.Postgres),
+                    stoppingToken
+                );
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Error while recording stream data");
+            }
+        }
+    }
+}

--- a/src/Beckett/Subscriptions/StreamDataQueue.cs
+++ b/src/Beckett/Subscriptions/StreamDataQueue.cs
@@ -1,0 +1,17 @@
+using System.Threading.Channels;
+
+namespace Beckett.Subscriptions;
+
+public static class StreamDataQueue
+{
+    private static readonly Channel<StreamData> _channel = Channel.CreateUnbounded<StreamData>();
+
+    public static ChannelReader<StreamData> Reader => _channel.Reader;
+
+    public static void Enqueue(string[] categories, DateTimeOffset[] categoryTimestamps, string[] tenants)
+    {
+        _channel.Writer.TryWrite(new StreamData(categories, categoryTimestamps, tenants));
+    }
+
+    public record StreamData(string[] Categories, DateTimeOffset[] CategoryTimestamps, string[] Tenants);
+}


### PR DESCRIPTION
- stream data recording fix to prevent deadlock when there are multiple subscription groups
- update `append_to_stream` function to lock at the stream level
- OTEL cleanup - remove unnecessary subscription group prefix for message handling activity name
- sample cleanup