### PR TITLE
Add ability to specify message ID when appending a message

### DIFF
--- a/src/Beckett.Tests/MessageTests.cs
+++ b/src/Beckett.Tests/MessageTests.cs
@@ -49,7 +49,7 @@ public class MessageTests
         var input = new TestMessage(Guid.NewGuid());
         var message = new Message(input);
 
-        message.WithId(expectedId);
+        message.WithMessageId(expectedId);
 
         Assert.Equal(expectedId, message.Id);
     }

--- a/src/Beckett.Tests/MessageTests.cs
+++ b/src/Beckett.Tests/MessageTests.cs
@@ -55,6 +55,18 @@ public class MessageTests
     }
 
     [Fact]
+    public void can_add_causation_id_to_message_metadata()
+    {
+        const string expectedCausationId = "causation-id";
+        var input = new TestMessage(Guid.NewGuid());
+        var message = new Message(input);
+
+        message.WithCausationId(expectedCausationId);
+
+        Assert.Single(message.Metadata, new KeyValuePair<string, string>("$causation_id", expectedCausationId));
+    }
+
+    [Fact]
     public void can_add_correlation_id_to_message_metadata()
     {
         const string expectedCorrelationId = "correlation-id";

--- a/src/Beckett.Tests/MessageTests.cs
+++ b/src/Beckett.Tests/MessageTests.cs
@@ -43,6 +43,18 @@ public class MessageTests
     }
 
     [Fact]
+    public void can_set_message_id()
+    {
+        var expectedId = Guid.NewGuid();
+        var input = new TestMessage(Guid.NewGuid());
+        var message = new Message(input);
+
+        message.WithId(expectedId);
+
+        Assert.Equal(expectedId, message.Id);
+    }
+
+    [Fact]
     public void can_add_correlation_id_to_message_metadata()
     {
         const string expectedCorrelationId = "correlation-id";

--- a/src/Beckett/Database/Types/MessageType.cs
+++ b/src/Beckett/Database/Types/MessageType.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using Beckett.Messages;
 
 namespace Beckett.Database.Types;
 
@@ -19,7 +18,7 @@ public class MessageType
     {
         return new MessageType
         {
-            Id = MessageId.New(),
+            Id = message.Id,
             StreamName = streamName,
             Type = message.Type,
             Data = message.Data,

--- a/src/Beckett/Message.cs
+++ b/src/Beckett/Message.cs
@@ -54,9 +54,17 @@ public class Message
         Metadata = metadata ?? new Dictionary<string, string>();
     }
 
+    public Guid Id { get; private set; } = MessageId.New();
     public string Type { get; }
     public JsonElement Data { get; }
     public Dictionary<string, string> Metadata { get; }
+
+    public Message WithId(Guid id)
+    {
+        Id = id;
+
+        return this;
+    }
 
     public Message WithMetadata(string key, string? value)
     {

--- a/src/Beckett/Message.cs
+++ b/src/Beckett/Message.cs
@@ -59,7 +59,7 @@ public class Message
     public JsonElement Data { get; }
     public Dictionary<string, string> Metadata { get; }
 
-    public Message WithId(Guid id)
+    public Message WithMessageId(Guid id)
     {
         Id = id;
 

--- a/src/Beckett/Message.cs
+++ b/src/Beckett/Message.cs
@@ -76,6 +76,11 @@ public class Message
         return this;
     }
 
+    public Message WithCausationId(string causationId) => WithMetadata(
+        MessageConstants.Metadata.CausationId,
+        causationId
+    );
+
     public Message WithCorrelationId(string correlationId) => WithMetadata(
         MessageConstants.Metadata.CorrelationId,
         correlationId


### PR DESCRIPTION
To support scenarios where you need to establish causation within a single batch of messages that are being appended, i.e. message A, B, and C are being appended in one go, and B and C are caused by A:
```csharp
messageA.WithMessageId(messageId),
messageB.WithCausationId(messageId.ToString()),
messageC.WithCausationId(messageId.ToString())
```