### PR TITLE
Filter stream reads

### DIFF
--- a/src/Beckett/Subscriptions/CheckpointProcessor.cs
+++ b/src/Beckett/Subscriptions/CheckpointProcessor.cs
@@ -291,7 +291,8 @@ public class CheckpointProcessor(
             new ReadStreamOptions
             {
                 StartingStreamPosition = startingStreamPosition,
-                EndingStreamPosition = endingStreamPosition
+                EndingStreamPosition = endingStreamPosition,
+                Types = subscription.MessageTypeNames.ToArray()
             },
             CancellationToken.None
         );

--- a/src/Beckett/Subscriptions/Initialization/SubscriptionInitializer.cs
+++ b/src/Beckett/Subscriptions/Initialization/SubscriptionInitializer.cs
@@ -104,7 +104,9 @@ public class SubscriptionInitializer(
                 new ReadGlobalStreamOptions
                 {
                     StartingGlobalPosition = checkpoint.StreamPosition,
-                    Count = options.Subscriptions.InitializationBatchSize
+                    Count = options.Subscriptions.InitializationBatchSize,
+                    Category = subscription.Category,
+                    Types = subscription.MessageTypeNames.ToArray()
                 },
                 cancellationToken
             );
@@ -132,7 +134,9 @@ public class SubscriptionInitializer(
                     new ReadGlobalStreamOptions
                     {
                         StartingGlobalPosition = checkpoint.StreamPosition,
-                        Count = 1
+                        Count = 1,
+                        Category = subscription.Category,
+                        Types = subscription.MessageTypeNames.ToArray()
                     },
                     cancellationToken
                 );


### PR DESCRIPTION
- add missing filtering for stream reads:
  - only read messages based on the category and/or types of a subscription during initialization
  - filter messages by type when doing stream reads during checkpoint processing (if there are no message types configured then the type filter will not apply)