### PR TITLE
Global read updates

### DIFF
--- a/db/migrations/001.sql
+++ b/db/migrations/001.sql
@@ -247,6 +247,50 @@ BEGIN
 END;
 $$;
 
+CREATE OR REPLACE FUNCTION __schema__.read_global_stream_checkpoint_data(
+  _starting_global_position bigint,
+  _batch_size int
+)
+  RETURNS TABLE (
+    stream_name text,
+    stream_position bigint,
+    global_position bigint,
+    type text,
+    tenant text,
+    "timestamp" timestamp with time zone
+  )
+  LANGUAGE plpgsql
+AS
+$$
+DECLARE
+  _transaction_id xid8;
+BEGIN
+  SELECT m.transaction_id
+  INTO _transaction_id
+  FROM __schema__.messages m
+  WHERE m.global_position = _starting_global_position
+  AND m.archived = false;
+
+  IF (_transaction_id IS NULL) THEN
+    _transaction_id = '0'::xid8;
+  END IF;
+
+  RETURN QUERY
+    SELECT m.stream_name,
+           m.stream_position,
+           m.global_position,
+           m.type,
+           m.metadata ->> '$tenant',
+           m.timestamp
+    FROM __schema__.messages m
+    WHERE (m.transaction_id, m.global_position) > (_transaction_id, _starting_global_position)
+    AND m.transaction_id < pg_snapshot_xmin(pg_current_snapshot())
+    AND m.archived = false
+    ORDER BY m.transaction_id, m.global_position
+    LIMIT _batch_size;
+END;
+$$;
+
 CREATE OR REPLACE FUNCTION __schema__.read_global_stream(
   _starting_global_position bigint,
   _count int,

--- a/db/versions/0.18.5.sql
+++ b/db/versions/0.18.5.sql
@@ -1,0 +1,99 @@
+-- Beckett v0.18.5 - add back query specific to reading checkpoint data from global stream, update read global stream to limit number of records read to avoid scans
+CREATE OR REPLACE FUNCTION beckett.read_global_stream_checkpoint_data(
+  _starting_global_position bigint,
+  _batch_size int
+)
+  RETURNS TABLE (
+    stream_name text,
+    stream_position bigint,
+    global_position bigint,
+    type text,
+    tenant text,
+    "timestamp" timestamp with time zone
+  )
+  LANGUAGE plpgsql
+AS
+$$
+DECLARE
+  _transaction_id xid8;
+BEGIN
+  SELECT m.transaction_id
+  INTO _transaction_id
+  FROM beckett.messages m
+  WHERE m.global_position = _starting_global_position
+  AND m.archived = false;
+
+  IF (_transaction_id IS NULL) THEN
+    _transaction_id = '0'::xid8;
+  END IF;
+
+  RETURN QUERY
+    SELECT m.stream_name,
+           m.stream_position,
+           m.global_position,
+           m.type,
+           m.metadata ->> '$tenant',
+           m.timestamp
+    FROM beckett.messages m
+    WHERE (m.transaction_id, m.global_position) > (_transaction_id, _starting_global_position)
+    AND m.transaction_id < pg_snapshot_xmin(pg_current_snapshot())
+    AND m.archived = false
+    ORDER BY m.transaction_id, m.global_position
+    LIMIT _batch_size;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION beckett.read_global_stream(
+  _starting_global_position bigint,
+  _count int,
+  _category text DEFAULT NULL,
+  _types text[] DEFAULT NULL
+)
+  RETURNS TABLE (
+    id uuid,
+    stream_name text,
+    stream_position bigint,
+    global_position bigint,
+    type text,
+    data jsonb,
+    metadata jsonb,
+    "timestamp" timestamp with time zone
+  )
+  LANGUAGE plpgsql
+AS
+$$
+DECLARE
+  _transaction_id xid8;
+  _ending_global_position bigint;
+BEGIN
+  SELECT m.transaction_id
+  INTO _transaction_id
+  FROM beckett.messages m
+  WHERE m.global_position = _starting_global_position
+  AND m.archived = false;
+
+  IF (_transaction_id IS NULL) THEN
+    _transaction_id = '0'::xid8;
+  END IF;
+
+  _ending_global_position = _starting_global_position + _count;
+
+  RETURN QUERY
+    SELECT m.id,
+           m.stream_name,
+           m.stream_position,
+           m.global_position,
+           m.type,
+           m.data,
+           m.metadata,
+           m.timestamp
+    FROM beckett.messages m
+    WHERE (m.transaction_id, m.global_position) > (_transaction_id, _starting_global_position)
+    AND m.global_position <= _ending_global_position
+    AND m.transaction_id < pg_snapshot_xmin(pg_current_snapshot())
+    AND m.archived = false
+    AND (_category IS NULL OR beckett.stream_category(m.stream_name) = _category)
+    AND (_types IS NULL OR m.type = ANY(_types))
+    ORDER BY m.transaction_id, m.global_position;
+END;
+$$;

--- a/src/Beckett/Database/IPostgresDatabase.cs
+++ b/src/Beckett/Database/IPostgresDatabase.cs
@@ -6,13 +6,28 @@ public interface IPostgresDatabase
 {
     Task<T> Execute<T>(IPostgresDatabaseQuery<T> query, CancellationToken cancellationToken);
 
+    Task<T> ExecuteWithRetry<T>(IPostgresDatabaseQuery<T> query, CancellationToken cancellationToken);
+
     Task<T> Execute<T>(
         IPostgresDatabaseQuery<T> query,
         NpgsqlConnection connection,
         CancellationToken cancellationToken
     );
 
+    Task<T> ExecuteWithRetry<T>(
+        IPostgresDatabaseQuery<T> query,
+        NpgsqlConnection connection,
+        CancellationToken cancellationToken
+    );
+
     Task<T> Execute<T>(
+        IPostgresDatabaseQuery<T> query,
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        CancellationToken cancellationToken
+    );
+
+    Task<T> ExecuteWithRetry<T>(
         IPostgresDatabaseQuery<T> query,
         NpgsqlConnection connection,
         NpgsqlTransaction transaction,

--- a/src/Beckett/MessageStorage/GlobalStreamItem.cs
+++ b/src/Beckett/MessageStorage/GlobalStreamItem.cs
@@ -6,7 +6,9 @@ public record GlobalStreamItem(
     string StreamName,
     long StreamPosition,
     long GlobalPosition,
-    string MessageType
+    string MessageType,
+    string? Tenant,
+    DateTimeOffset Timestamp
 )
 {
     public bool AppliesTo(Subscription subscription)

--- a/src/Beckett/MessageStorage/IMessageStorage.cs
+++ b/src/Beckett/MessageStorage/IMessageStorage.cs
@@ -9,6 +9,12 @@ public interface IMessageStorage
         CancellationToken cancellationToken
     );
 
+    Task<ReadGlobalStreamCheckpointDataResult> ReadGlobalStreamCheckpointData(
+        long lastGlobalPosition,
+        int batchSize,
+        CancellationToken cancellationToken
+    );
+
     Task<ReadGlobalStreamResult> ReadGlobalStream(
         ReadGlobalStreamOptions options,
         CancellationToken cancellationToken

--- a/src/Beckett/MessageStorage/Postgres/PostgresMessageStorage.cs
+++ b/src/Beckett/MessageStorage/Postgres/PostgresMessageStorage.cs
@@ -22,7 +22,7 @@ public class PostgresMessageStorage(
 
         await connection.OpenAsync(cancellationToken);
 
-        var streamVersion = await database.Execute(
+        var streamVersion = await database.ExecuteWithRetry(
             new AppendToStream(streamName, expectedVersion.Value, newMessages, options),
             connection,
             cancellationToken

--- a/src/Beckett/MessageStorage/Postgres/PostgresMessageStorage.cs
+++ b/src/Beckett/MessageStorage/Postgres/PostgresMessageStorage.cs
@@ -31,6 +31,45 @@ public class PostgresMessageStorage(
         return new AppendToStreamResult(streamVersion);
     }
 
+    public async Task<ReadGlobalStreamCheckpointDataResult> ReadGlobalStreamCheckpointData(
+        long lastGlobalPosition,
+        int batchSize,
+        CancellationToken cancellationToken
+    )
+    {
+        await using var connection = dataSource.CreateMessageStoreReadConnection();
+
+        await connection.OpenAsync(cancellationToken);
+
+        var results = await database.Execute(
+            new ReadGlobalStreamCheckpointData(lastGlobalPosition, batchSize, options),
+            connection,
+            cancellationToken
+        );
+
+        var items = new List<GlobalStreamItem>();
+
+        if (results.Count <= 0)
+        {
+            return new ReadGlobalStreamCheckpointDataResult(items);
+        }
+
+        items.AddRange(
+            results.Select(
+                result => new GlobalStreamItem(
+                    result.StreamName,
+                    result.StreamPosition,
+                    result.GlobalPosition,
+                    result.MessageType,
+                    result.Tenant,
+                    result.Timestamp
+                )
+            )
+        );
+
+        return new ReadGlobalStreamCheckpointDataResult(items);
+    }
+
     public async Task<ReadGlobalStreamResult> ReadGlobalStream(
         ReadGlobalStreamOptions readOptions,
         CancellationToken cancellationToken

--- a/src/Beckett/MessageStorage/Postgres/Queries/ReadGlobalStream.cs
+++ b/src/Beckett/MessageStorage/Postgres/Queries/ReadGlobalStream.cs
@@ -16,7 +16,7 @@ public class ReadGlobalStream(ReadGlobalStreamOptions readOptions, PostgresOptio
         command.CommandText = $@"
             select id,
                    stream_name,
-                   0 as stream_version,
+                   global_position as stream_version,
                    stream_position,
                    global_position,
                    type,

--- a/src/Beckett/MessageStorage/Postgres/Queries/ReadGlobalStreamCheckpointData.cs
+++ b/src/Beckett/MessageStorage/Postgres/Queries/ReadGlobalStreamCheckpointData.cs
@@ -1,0 +1,60 @@
+using Beckett.Database;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace Beckett.MessageStorage.Postgres.Queries;
+
+public class ReadGlobalStreamCheckpointData(
+    long lastGlobalPosition,
+    int batchSize,
+    PostgresOptions options
+) : IPostgresDatabaseQuery<IReadOnlyList<ReadGlobalStreamCheckpointData.Result>>
+{
+    public async Task<IReadOnlyList<Result>> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
+    {
+        command.CommandText = $@"
+            select stream_name, stream_position, global_position, type, tenant, timestamp
+            from {options.Schema}.read_global_stream_checkpoint_data($1, $2);
+        ";
+
+        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Bigint });
+        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Integer });
+
+        if (options.PrepareStatements)
+        {
+            await command.PrepareAsync(cancellationToken);
+        }
+
+        command.Parameters[0].Value = lastGlobalPosition;
+        command.Parameters[1].Value = batchSize;
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+
+        var results = new List<Result>();
+
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            results.Add(
+                new Result(
+                    reader.GetFieldValue<string>(0),
+                    reader.GetFieldValue<long>(1),
+                    reader.GetFieldValue<long>(2),
+                    reader.GetFieldValue<string>(3),
+                    reader.IsDBNull(4) ? null : reader.GetFieldValue<string>(4),
+                    reader.GetFieldValue<DateTimeOffset>(5)
+                )
+            );
+        }
+
+        return results;
+    }
+
+    public readonly record struct Result(
+        string StreamName,
+        long StreamPosition,
+        long GlobalPosition,
+        string MessageType,
+        string? Tenant,
+        DateTimeOffset Timestamp
+    );
+}

--- a/src/Beckett/MessageStorage/ReadGlobalStreamCheckpointDataResult.cs
+++ b/src/Beckett/MessageStorage/ReadGlobalStreamCheckpointDataResult.cs
@@ -1,0 +1,3 @@
+namespace Beckett.MessageStorage;
+
+public record ReadGlobalStreamCheckpointDataResult(IReadOnlyList<GlobalStreamItem> Items);

--- a/src/Beckett/Subscriptions/CheckpointProcessor.cs
+++ b/src/Beckett/Subscriptions/CheckpointProcessor.cs
@@ -105,13 +105,15 @@ public class CheckpointProcessor(
         {
             if (messageBatch.Count == 0)
             {
-                if (checkpoint.StreamPosition < checkpoint.StreamVersion &&
-                    subscription.StreamScope == StreamScope.GlobalStream)
+                if (subscription.StreamScope == StreamScope.PerStream ||
+                    checkpoint.StreamPosition >= checkpoint.StreamVersion)
                 {
-                    return new Success(checkpoint.StreamVersion);
+                    return NoMessages.Instance;
                 }
 
-                return NoMessages.Instance;
+                var readPosition = checkpoint.StreamPosition + options.Subscriptions.SubscriptionStreamBatchSize;
+
+                return new Success(readPosition);
             }
 
             if (subscription.Handler.IsBatchHandler)

--- a/src/Beckett/Subscriptions/Services/StreamDataRecordingService.cs
+++ b/src/Beckett/Subscriptions/Services/StreamDataRecordingService.cs
@@ -19,7 +19,7 @@ public class StreamDataRecordingService(
             {
                 await database.Execute(
                     new RecordStreamData(data.Categories, data.CategoryTimestamps, data.Tenants, options.Postgres),
-                    stoppingToken
+                    CancellationToken.None
                 );
             }
             catch (Exception e)


### PR DESCRIPTION
- database retries should be explicit - only use for appends for now
- only read data necessary for checkpoints when initializing subscriptions and in the global stream consumer
  - the change to read the entire message via global stream read everywhere caused performance issues
- cap global stream reads by count - i.e. limit the number of rows that can be queried by looking at a range of global positions vs a potential table scan resulting from using a `limit` instead