### PR TITLE
Fix Polly retry policy usage

### DIFF
--- a/src/Beckett/Database/IPostgresDatabase.cs
+++ b/src/Beckett/Database/IPostgresDatabase.cs
@@ -6,28 +6,13 @@ public interface IPostgresDatabase
 {
     Task<T> Execute<T>(IPostgresDatabaseQuery<T> query, CancellationToken cancellationToken);
 
-    Task<T> ExecuteWithRetry<T>(IPostgresDatabaseQuery<T> query, CancellationToken cancellationToken);
-
     Task<T> Execute<T>(
         IPostgresDatabaseQuery<T> query,
         NpgsqlConnection connection,
         CancellationToken cancellationToken
     );
 
-    Task<T> ExecuteWithRetry<T>(
-        IPostgresDatabaseQuery<T> query,
-        NpgsqlConnection connection,
-        CancellationToken cancellationToken
-    );
-
     Task<T> Execute<T>(
-        IPostgresDatabaseQuery<T> query,
-        NpgsqlConnection connection,
-        NpgsqlTransaction transaction,
-        CancellationToken cancellationToken
-    );
-
-    Task<T> ExecuteWithRetry<T>(
         IPostgresDatabaseQuery<T> query,
         NpgsqlConnection connection,
         NpgsqlTransaction transaction,

--- a/src/Beckett/MessageStorage/Postgres/PostgresMessageStorage.cs
+++ b/src/Beckett/MessageStorage/Postgres/PostgresMessageStorage.cs
@@ -22,7 +22,7 @@ public class PostgresMessageStorage(
 
         await connection.OpenAsync(cancellationToken);
 
-        var streamVersion = await database.ExecuteWithRetry(
+        var streamVersion = await database.Execute(
             new AppendToStream(streamName, expectedVersion.Value, newMessages, options),
             connection,
             cancellationToken


### PR DESCRIPTION
- previous implementation was reusing the command object between retry attempts resulting in duplicate parameters being added to the collection each time which prevented the successful execution of each subsequent retry attempt
- made retries the default behavior again