### PR TITLE
Record stream data in batches

### DIFF
--- a/src/Beckett/Subscriptions/ChannelReaderExtensions.cs
+++ b/src/Beckett/Subscriptions/ChannelReaderExtensions.cs
@@ -1,0 +1,95 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+
+namespace Beckett.Subscriptions;
+
+public static class ChannelReaderExtensions
+{
+    public static IAsyncEnumerable<T[]> BatchReadAllAsync<T>(
+        this ChannelReader<T> source,
+        int batchSize,
+        TimeSpan timeout
+    )
+    {
+        return ReadBatches();
+
+        async IAsyncEnumerable<T[]> ReadBatches(
+            [EnumeratorCancellation] CancellationToken cancellationToken = default
+        )
+        {
+            var timer = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+            try
+            {
+                List<T> buffer = [];
+
+                while (true)
+                {
+                    var token = buffer.Count == 0 ? cancellationToken : timer.Token;
+
+                    var item = default(T);
+
+                    try
+                    {
+                        item = await source.ReadAsync(token);
+                    }
+                    catch (ChannelClosedException)
+                    {
+                        break;
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        if (cancellationToken.IsCancellationRequested)
+                        {
+                            break;
+                        }
+                    }
+
+                    if (buffer.Count == 0)
+                    {
+                        timer.CancelAfter(timeout);
+                    }
+
+                    if (item != null)
+                    {
+                        buffer.Add(item);
+
+                        if (buffer.Count < batchSize)
+                        {
+                            continue;
+                        }
+                    }
+
+                    yield return buffer.ToArray();
+
+                    buffer.Clear();
+
+                    if (timer.TryReset())
+                    {
+                        continue;
+                    }
+
+                    timer.Dispose();
+
+                    timer = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                }
+
+                if (buffer.Count > 0)
+                {
+                    yield return buffer.ToArray();
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (source.Completion.IsCompleted)
+                {
+                    await source.Completion;
+                }
+            }
+            finally
+            {
+                timer.Dispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
- change stream data recorder to write data in batches
- it will wait for a batch of up to 100 items for 10 seconds, if it times out then it will return whatever it has at that time
- this is to add a cushion to prevent deadlocks writing to these tables - with the recent performance improvements under load locking has become much more prevalent. between this and the now correctly functioning Polly retry strategies we should be good to go