### PR TITLE
Add category and type filtering to read index batch

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,7 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 
 # ReSharper properties
+resharper_bitwise_operator_on_enum_without_flags_highlighting = none
 resharper_braces_for_ifelse = required
 resharper_braces_for_while = required
 resharper_csharp_wrap_after_declaration_lpar = true

--- a/db/versions/0.18.10.sql
+++ b/db/versions/0.18.10.sql
@@ -1,6 +1,22 @@
 -- Beckett v0.18.10 - subscription initialization fixes and improvements
 ALTER TYPE beckett.checkpoint ADD ATTRIBUTE stream_position bigint;
 
+CREATE OR REPLACE FUNCTION beckett.get_checkpoint_stream_version(
+  _group_name text,
+  _name text,
+  _stream_name text
+)
+  RETURNS bigint
+  LANGUAGE sql
+AS
+$$
+SELECT stream_version
+FROM beckett.checkpoints
+WHERE group_name = _group_name
+AND name = _name
+AND stream_name = _stream_name;
+$$;
+
 CREATE OR REPLACE FUNCTION beckett.record_checkpoints(
   _checkpoints beckett.checkpoint[]
 )

--- a/db/versions/0.18.10.sql
+++ b/db/versions/0.18.10.sql
@@ -14,3 +14,57 @@ FROM unnest(_checkpoints) c
 ON CONFLICT (group_name, name, stream_name) DO UPDATE
   SET stream_version = excluded.stream_version;
 $$;
+
+DROP FUNCTION IF EXISTS beckett.read_global_stream_checkpoint_data(bigint, int);
+
+CREATE OR REPLACE FUNCTION beckett.read_index_batch(
+  _starting_global_position bigint,
+  _batch_size int,
+  _category text DEFAULT NULL,
+  _types text[] DEFAULT NULL
+)
+  RETURNS TABLE (
+    stream_name text,
+    stream_position bigint,
+    global_position bigint,
+    type text,
+    tenant text,
+    "timestamp" timestamp with time zone
+  )
+  LANGUAGE plpgsql
+AS
+$$
+DECLARE
+  _transaction_id xid8;
+  _ending_global_position bigint;
+BEGIN
+  SELECT m.transaction_id
+  INTO _transaction_id
+  FROM beckett.messages m
+  WHERE m.global_position = _starting_global_position
+  AND m.archived = false;
+
+  IF (_transaction_id IS NULL) THEN
+    _transaction_id = '0'::xid8;
+  END IF;
+
+  _ending_global_position = _starting_global_position + _batch_size;
+
+  RETURN QUERY
+    SELECT m.stream_name,
+           m.stream_position,
+           m.global_position,
+           m.type,
+           m.metadata ->> '$tenant',
+           m.timestamp
+    FROM beckett.messages m
+    WHERE (m.transaction_id, m.global_position) > (_transaction_id, _starting_global_position)
+    AND (m.global_position > _starting_global_position AND m.global_position <= _ending_global_position)
+    AND m.transaction_id < pg_snapshot_xmin(pg_current_snapshot())
+    AND m.archived = false
+    AND (_category IS NULL OR beckett.stream_category(m.stream_name) = _category)
+    AND (_types IS NULL OR m.type = ANY(_types))
+    ORDER BY m.transaction_id, m.global_position
+    LIMIT _batch_size;
+END;
+$$;

--- a/src/Beckett/MessageStorage/IMessageStorage.cs
+++ b/src/Beckett/MessageStorage/IMessageStorage.cs
@@ -9,14 +9,13 @@ public interface IMessageStorage
         CancellationToken cancellationToken
     );
 
-    Task<ReadGlobalStreamCheckpointDataResult> ReadGlobalStreamCheckpointData(
-        long lastGlobalPosition,
-        int batchSize,
+    Task<ReadGlobalStreamResult> ReadGlobalStream(
+        ReadGlobalStreamOptions options,
         CancellationToken cancellationToken
     );
 
-    Task<ReadGlobalStreamResult> ReadGlobalStream(
-        ReadGlobalStreamOptions options,
+    Task<ReadIndexBatchResult> ReadIndexBatch(
+        ReadIndexBatchOptions options,
         CancellationToken cancellationToken
     );
 

--- a/src/Beckett/MessageStorage/InMemory/InMemoryMessageStorage.cs
+++ b/src/Beckett/MessageStorage/InMemory/InMemoryMessageStorage.cs
@@ -50,13 +50,18 @@ public class InMemoryMessageStorage : IMessageStorage
         return Task.FromResult(new AppendToStreamResult(newStreamVersion));
     }
 
-    public async Task<ReadGlobalStreamCheckpointDataResult> ReadGlobalStreamCheckpointData(long lastGlobalPosition, int batchSize, CancellationToken cancellationToken)
+    public async Task<ReadIndexBatchResult> ReadIndexBatch(
+        ReadIndexBatchOptions options,
+        CancellationToken cancellationToken
+    )
     {
         var globalStream = await ReadGlobalStream(
             new ReadGlobalStreamOptions
             {
-                StartingGlobalPosition = lastGlobalPosition,
-                Count = batchSize
+                StartingGlobalPosition = options.StartingGlobalPosition,
+                Count = options.BatchSize,
+                Category = options.Category,
+                Types = options.Types
             },
             cancellationToken
         );
@@ -70,7 +75,7 @@ public class InMemoryMessageStorage : IMessageStorage
                     tenant = tenantProperty.GetString();
                 }
 
-                return new GlobalStreamItem(
+                return new IndexBatchItem(
                     x.StreamName,
                     x.StreamPosition,
                     x.GlobalPosition,
@@ -81,7 +86,7 @@ public class InMemoryMessageStorage : IMessageStorage
             }
         ).ToList();
 
-        return new ReadGlobalStreamCheckpointDataResult(items);
+        return new ReadIndexBatchResult(items);
     }
 
     public Task<ReadGlobalStreamResult> ReadGlobalStream(

--- a/src/Beckett/MessageStorage/IndexBatchItem.cs
+++ b/src/Beckett/MessageStorage/IndexBatchItem.cs
@@ -2,7 +2,7 @@ using Beckett.Subscriptions;
 
 namespace Beckett.MessageStorage;
 
-public record GlobalStreamItem(
+public record IndexBatchItem(
     string StreamName,
     long StreamPosition,
     long GlobalPosition,

--- a/src/Beckett/MessageStorage/ReadGlobalStreamCheckpointDataResult.cs
+++ b/src/Beckett/MessageStorage/ReadGlobalStreamCheckpointDataResult.cs
@@ -1,3 +1,0 @@
-namespace Beckett.MessageStorage;
-
-public record ReadGlobalStreamCheckpointDataResult(IReadOnlyList<GlobalStreamItem> Items);

--- a/src/Beckett/MessageStorage/ReadIndexBatchOptions.cs
+++ b/src/Beckett/MessageStorage/ReadIndexBatchOptions.cs
@@ -1,0 +1,9 @@
+namespace Beckett.MessageStorage;
+
+public class ReadIndexBatchOptions
+{
+    public required long StartingGlobalPosition { get; init; }
+    public required int BatchSize { get; init; }
+    public string? Category { get; init; }
+    public string[]? Types { get; init; }
+}

--- a/src/Beckett/MessageStorage/ReadIndexBatchResult.cs
+++ b/src/Beckett/MessageStorage/ReadIndexBatchResult.cs
@@ -1,0 +1,3 @@
+namespace Beckett.MessageStorage;
+
+public record ReadIndexBatchResult(IReadOnlyList<IndexBatchItem> Items);

--- a/src/Beckett/Subscriptions/Initialization/SubscriptionInitializer.cs
+++ b/src/Beckett/Subscriptions/Initialization/SubscriptionInitializer.cs
@@ -4,6 +4,7 @@ using Beckett.Database.Types;
 using Beckett.MessageStorage;
 using Beckett.Subscriptions.Queries;
 using Microsoft.Extensions.Logging;
+using Npgsql;
 
 namespace Beckett.Subscriptions.Initialization;
 
@@ -19,8 +20,13 @@ public class SubscriptionInitializer(
     {
         while (!cancellationToken.IsCancellationRequested)
         {
+            await using var connection = dataSource.CreateConnection();
+
+            await connection.OpenAsync(cancellationToken);
+
             var subscriptionName = await database.Execute(
                 new GetNextUninitializedSubscription(options.Subscriptions.GroupName, options.Postgres),
+                connection,
                 cancellationToken
             );
 
@@ -33,7 +39,10 @@ public class SubscriptionInitializer(
 
             if (subscription == null)
             {
-                logger.LogWarning("Uninitialized subscription {SubscriptionName} does not exist - setting status to 'unknown'", subscriptionName);
+                logger.LogWarning(
+                    "Uninitialized subscription {SubscriptionName} does not exist - setting status to 'unknown'",
+                    subscriptionName
+                );
 
                 await database.Execute(
                     new SetSubscriptionStatus(
@@ -42,6 +51,7 @@ public class SubscriptionInitializer(
                         SubscriptionStatus.Unknown,
                         options.Postgres
                     ),
+                    connection,
                     cancellationToken
                 );
 
@@ -52,6 +62,7 @@ public class SubscriptionInitializer(
 
             var locked = await database.Execute(
                 new TryAdvisoryLock(advisoryLockKey, options.Postgres),
+                connection,
                 cancellationToken
             );
 
@@ -66,13 +77,19 @@ public class SubscriptionInitializer(
             }
             finally
             {
-                await database.Execute(new AdvisoryUnlock(advisoryLockKey, options.Postgres), cancellationToken);
+                await database.Execute(
+                    new AdvisoryUnlock(advisoryLockKey, options.Postgres),
+                    connection,
+                    cancellationToken
+                );
             }
         }
     }
 
     private async Task InitializeSubscription(Subscription subscription, CancellationToken cancellationToken)
     {
+        long? globalCheckpointPosition = null;
+
         while (!cancellationToken.IsCancellationRequested)
         {
             await using var connection = dataSource.CreateConnection();
@@ -111,9 +128,18 @@ public class SubscriptionInitializer(
                 cancellationToken
             );
 
+            var subscriptionGlobalPosition = checkpoint.StreamPosition + options.Subscriptions.InitializationBatchSize;
+
+            globalCheckpointPosition ??= await GetGlobalCheckpointPosition(connection, cancellationToken);
+
             if (batch.Items.Count == 0)
             {
-                var globalStreamCheck = await database.Execute(
+                if (subscriptionGlobalPosition < globalCheckpointPosition.Value)
+                {
+                    continue;
+                }
+
+                var globalCheckpoint = await database.Execute(
                     new LockCheckpoint(
                         options.Subscriptions.GroupName,
                         GlobalCheckpoint.Name,
@@ -125,7 +151,13 @@ public class SubscriptionInitializer(
                     cancellationToken
                 );
 
-                if (globalStreamCheck == null)
+                if (globalCheckpoint == null)
+                {
+                    continue;
+                }
+
+                //if the global stream position is greater than the previously known max position try again
+                if (globalCheckpoint.StreamPosition > globalCheckpointPosition.Value)
                 {
                     continue;
                 }
@@ -133,7 +165,7 @@ public class SubscriptionInitializer(
                 var nextBatch = await messageStorage.ReadIndexBatch(
                     new ReadIndexBatchOptions
                     {
-                        StartingGlobalPosition = checkpoint.StreamPosition,
+                        StartingGlobalPosition = subscriptionGlobalPosition,
                         BatchSize = 1,
                         Category = subscription.Category,
                         Types = subscription.MessageTypeNames.ToArray()
@@ -205,6 +237,21 @@ public class SubscriptionInitializer(
             logger.SubscriptionInitializationPosition(subscription.Name, newGlobalPosition);
         }
     }
+
+    private async Task<long> GetGlobalCheckpointPosition(
+        NpgsqlConnection connection,
+        CancellationToken cancellationToken
+    ) =>
+        await database.Execute(
+            new GetCheckpointStreamVersion(
+                options.Subscriptions.GroupName,
+                GlobalCheckpoint.Name,
+                GlobalCheckpoint.StreamName,
+                options.Postgres
+            ),
+            connection,
+            cancellationToken
+        );
 }
 
 public static partial class Log

--- a/src/Beckett/Subscriptions/Queries/GetCheckpointStreamVersion.cs
+++ b/src/Beckett/Subscriptions/Queries/GetCheckpointStreamVersion.cs
@@ -1,0 +1,39 @@
+using Beckett.Database;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace Beckett.Subscriptions.Queries;
+
+public class GetCheckpointStreamVersion(
+    string groupName,
+    string name,
+    string streamName,
+    PostgresOptions options
+) : IPostgresDatabaseQuery<long>
+{
+    public async Task<long> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
+    {
+        command.CommandText = $"select {options.Schema}.get_checkpoint_stream_version($1, $2, $3);";
+
+        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
+        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
+        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
+
+        if (options.PrepareStatements)
+        {
+            await command.PrepareAsync(cancellationToken);
+        }
+
+        command.Parameters[0].Value = groupName;
+        command.Parameters[1].Value = name;
+        command.Parameters[2].Value = streamName;
+
+        var result = await command.ExecuteScalarAsync(cancellationToken);
+
+        return result switch
+        {
+            long id => id,
+            _ => throw new Exception($"Unexpected result from get_checkpoint_stream_version function: {result}")
+        };
+    }
+}


### PR DESCRIPTION
- rename `read_global_stream_checkpoint_data` to `read_index_batch`
  - move towards future indexer concept
- add category and type filters to read index batch call to optimize subscription initialization