### PR TITLE
Initial support for subscription partition strategies

### DIFF
--- a/src/Beckett/StreamScope.cs
+++ b/src/Beckett/StreamScope.cs
@@ -1,7 +1,0 @@
-namespace Beckett;
-
-public enum StreamScope
-{
-    PerStream,
-    GlobalStream
-}

--- a/src/Beckett/Subscriptions/Checkpoint.cs
+++ b/src/Beckett/Subscriptions/Checkpoint.cs
@@ -1,3 +1,4 @@
+using Beckett.Subscriptions.PartitionStrategies;
 using Npgsql;
 
 namespace Beckett.Subscriptions;
@@ -18,12 +19,16 @@ public record Checkpoint(
 
     public long StartingPositionFor(Subscription subscription)
     {
-        return subscription.StreamScope == StreamScope.PerStream ? StreamPosition + 1 : StreamPosition;
+        return subscription.PartitionStrategy is not GlobalStreamPartitionStrategy
+            ? StreamPosition + 1
+            : StreamPosition;
     }
 
     public long RetryStartingPositionFor(Subscription subscription)
     {
-        return subscription.StreamScope == StreamScope.PerStream ? StreamPosition : StreamPosition - 1;
+        return subscription.PartitionStrategy is not GlobalStreamPartitionStrategy
+            ? StreamPosition
+            : StreamPosition - 1;
     }
 
     public static Checkpoint? From(NpgsqlDataReader reader)

--- a/src/Beckett/Subscriptions/Configuration/ISubscriptionConfigurationBuilder.cs
+++ b/src/Beckett/Subscriptions/Configuration/ISubscriptionConfigurationBuilder.cs
@@ -107,14 +107,19 @@ public interface ISubscriptionConfigurationBuilder
     ISubscriptionConfigurationBuilder StartingPosition(StartingPosition startingPosition);
 
     /// <summary>
-    /// Configure the stream scope of the subscription. By default Beckett tracks checkpoints per stream which is the
-    /// same as the <c>StreamScope.PerStream</c>. For certain situations having a subscription have a single checkpoint
-    /// and consume the global stream instead is preferred, for example projections where bulk persistence is used to
-    /// increase performance.
+    /// Configure the subscription to partition checkpoints by stream. Checkpoints will be tracked for each stream
+    /// that matches the subscription configuration and processed in parallel based on the concurrency level configured
+    /// for the group the subscription belongs to.
     /// </summary>
-    /// <param name="streamScope">Stream scope of the subscription</param>
     /// <returns>Builder to further configure the subscription</returns>
-    ISubscriptionConfigurationBuilder StreamScope(StreamScope streamScope);
+    ISubscriptionConfigurationBuilder PartitionByStream();
+
+    /// <summary>
+    /// Configure the subscription to track a single checkpoint based on the global stream. Messages will be processed
+    /// in global order in batches using the configured batch size.
+    /// </summary>
+    /// <returns>Builder to further configure the subscription</returns>
+    ISubscriptionConfigurationBuilder PartitionByGlobalStream();
 
     /// <summary>
     /// Configure the default max retry count for this subscription. This will override the max retry count configured

--- a/src/Beckett/Subscriptions/Configuration/SubscriptionConfigurationBuilder.cs
+++ b/src/Beckett/Subscriptions/Configuration/SubscriptionConfigurationBuilder.cs
@@ -1,3 +1,4 @@
+using Beckett.Subscriptions.PartitionStrategies;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Beckett.Subscriptions.Configuration;
@@ -80,9 +81,16 @@ public class SubscriptionConfigurationBuilder(
         return this;
     }
 
-    public ISubscriptionConfigurationBuilder StreamScope(StreamScope streamScope)
+    public ISubscriptionConfigurationBuilder PartitionByStream()
     {
-        subscription.StreamScope = streamScope;
+        subscription.PartitionStrategy = PerStreamPartitionStrategy.Instance;
+
+        return this;
+    }
+
+    public ISubscriptionConfigurationBuilder PartitionByGlobalStream()
+    {
+        subscription.PartitionStrategy = GlobalStreamPartitionStrategy.Instance;
 
         return this;
     }

--- a/src/Beckett/Subscriptions/GlobalStreamConsumer.cs
+++ b/src/Beckett/Subscriptions/GlobalStreamConsumer.cs
@@ -2,6 +2,7 @@ using System.Threading.Channels;
 using Beckett.Database;
 using Beckett.Database.Types;
 using Beckett.Storage;
+using Beckett.Subscriptions.PartitionStrategies;
 using Beckett.Subscriptions.Queries;
 using Microsoft.Extensions.Logging;
 
@@ -75,7 +76,7 @@ public class GlobalStreamConsumer(
                 var checkpoints = new HashSet<CheckpointType>(CheckpointType.Comparer);
 
                 var globalStreamSubscriptions = registeredSubscriptions
-                    .Where(x => x.StreamScope == StreamScope.GlobalStream)
+                    .Where(x => x.PartitionStrategy is GlobalStreamPartitionStrategy)
                     .Where(x => batch.Items.Any(m => m.AppliesTo(x))).OrderBy(x => x.Priority)
                     .ToArray();
 
@@ -104,7 +105,7 @@ public class GlobalStreamConsumer(
                 foreach (var stream in batch.Items.GroupBy(x => x.StreamName))
                 {
                     var subscriptions = registeredSubscriptions
-                        .Where(x => x.StreamScope == StreamScope.PerStream)
+                        .Where(x => x.PartitionStrategy is not GlobalStreamPartitionStrategy)
                         .Where(subscription => stream.Any(m => m.AppliesTo(subscription)))
                         .OrderBy(subscription => subscription.Priority).ToArray();
 

--- a/src/Beckett/Subscriptions/PartitionStrategies/GlobalStreamPartitionStrategy.cs
+++ b/src/Beckett/Subscriptions/PartitionStrategies/GlobalStreamPartitionStrategy.cs
@@ -1,0 +1,8 @@
+namespace Beckett.Subscriptions.PartitionStrategies;
+
+public class GlobalStreamPartitionStrategy : IPartitionStrategy
+{
+    public static readonly GlobalStreamPartitionStrategy Instance = new();
+
+    public string PartitionKey(IMessageContext _) => GlobalStream.Name;
+}

--- a/src/Beckett/Subscriptions/PartitionStrategies/IPartitionStrategy.cs
+++ b/src/Beckett/Subscriptions/PartitionStrategies/IPartitionStrategy.cs
@@ -1,0 +1,6 @@
+namespace Beckett.Subscriptions.PartitionStrategies;
+
+public interface IPartitionStrategy
+{
+    string PartitionKey(IMessageContext context);
+}

--- a/src/Beckett/Subscriptions/PartitionStrategies/PerStreamPartitionStrategy.cs
+++ b/src/Beckett/Subscriptions/PartitionStrategies/PerStreamPartitionStrategy.cs
@@ -1,0 +1,8 @@
+namespace Beckett.Subscriptions.PartitionStrategies;
+
+public class PerStreamPartitionStrategy : IPartitionStrategy
+{
+    public static readonly PerStreamPartitionStrategy Instance = new();
+
+    public string PartitionKey(IMessageContext context) => context.StreamName;
+}

--- a/src/Beckett/Subscriptions/Services/BootstrapSubscriptions.cs
+++ b/src/Beckett/Subscriptions/Services/BootstrapSubscriptions.cs
@@ -1,6 +1,7 @@
 using Beckett.Database;
 using Beckett.Database.Types;
 using Beckett.Subscriptions.Initialization;
+using Beckett.Subscriptions.PartitionStrategies;
 using Beckett.Subscriptions.Queries;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -99,7 +100,7 @@ public class BootstrapSubscriptions(
                 continue;
             }
 
-            if (subscription.StreamScope == StreamScope.GlobalStream)
+            if (subscription.PartitionStrategy is GlobalStreamPartitionStrategy)
             {
                 logger.LogTrace(
                     "Subscription {Name} in group {GroupName} is scoped to the global stream so it will be set to active and will start processing messages from the {StartingPosition} of the global stream.",
@@ -146,8 +147,6 @@ public class BootstrapSubscriptions(
                         stoppingToken
                     );
                 }
-
-                await transaction.CommitAsync(stoppingToken);
 
                 continue;
             }

--- a/src/Beckett/Subscriptions/Subscription.cs
+++ b/src/Beckett/Subscriptions/Subscription.cs
@@ -1,4 +1,5 @@
 using Beckett.Messages;
+using Beckett.Subscriptions.PartitionStrategies;
 
 namespace Beckett.Subscriptions;
 
@@ -14,7 +15,7 @@ public class Subscription(SubscriptionGroup group, string name)
     internal SubscriptionHandler Handler { get; private set; } = null!;
     internal string? HandlerName { get; set; }
     internal StartingPosition StartingPosition { get; set; } = StartingPosition.Latest;
-    internal StreamScope StreamScope { get; set; } = StreamScope.PerStream;
+    internal IPartitionStrategy PartitionStrategy { get; set; } = PerStreamPartitionStrategy.Instance;
     internal Dictionary<Type, int> MaxRetriesByExceptionType { get; } = [];
     internal int Priority { get; set; } = int.MaxValue;
     internal bool SkipDuringReplay { get; set; }


### PR DESCRIPTION
- initial support for subscription partition strategies
- for now there's only two built-in strategies - per-stream and global stream, but in a future version you will be able to implement custom partition strategies - this PR is setting the stage for that in the configuration builder