### PR TITLE
Typed batch configuration fix

### DIFF
--- a/src/Beckett.Tests/Subscriptions/SubscriptionHandlerTests.cs
+++ b/src/Beckett.Tests/Subscriptions/SubscriptionHandlerTests.cs
@@ -119,6 +119,22 @@ public class SubscriptionHandlerTests
     }
 
     [Fact]
+    public async Task supports_batch_handler_with_multiple_message_types()
+    {
+        _subscription.RegisterMessageType<TestMessage>();
+        _subscription.RegisterMessageType<AnotherTestMessage>();
+        var handler = new SubscriptionHandler(_subscription, BatchHandler.Handle);
+        var batch = BuildMessageBatch();
+        var subscriptionContext = BuildSubscriptionContext();
+
+        await handler.Invoke(batch, subscriptionContext, _serviceProvider, _logger, CancellationToken.None);
+
+        Assert.True(handler.IsBatchHandler);
+        Assert.NotNull(BatchHandler.ReceivedBatch);
+        Assert.Equal(batch, BatchHandler.ReceivedBatch);
+    }
+
+    [Fact]
     public async Task supports_typed_batch_handler()
     {
         _subscription.RegisterMessageType<TestMessage>();

--- a/src/Beckett/Subscriptions/SubscriptionHandler.cs
+++ b/src/Beckett/Subscriptions/SubscriptionHandler.cs
@@ -237,14 +237,14 @@ public class SubscriptionHandler
         if (typedMessageHandler && _subscription.MessageTypes.Count > 1)
         {
             throw new InvalidOperationException(
-                $"$Typed handlers can only subscribe to one message type [Subscription: {_subscription.Name}]"
+                $"Typed handlers can only subscribe to one message type [Subscription: {_subscription.Name}]"
             );
         }
 
         if (typedBatchHandler && _subscription.MessageTypes.Count > 1)
         {
             throw new InvalidOperationException(
-                $"$Typed batch handlers can only subscribe to one message type [Subscription: {_subscription.Name}]"
+                $"Typed batch handlers can only subscribe to one message type [Subscription: {_subscription.Name}]"
             );
         }
 
@@ -285,6 +285,8 @@ public class SubscriptionHandler
         parameter.ParameterType.GetGenericTypeDefinition() == TypedMessageContextType;
 
     private static bool IsTypedBatch(ParameterInfo parameter) => parameter.ParameterType.IsGenericType &&
+                                                                 parameter.ParameterType != BatchType &&
+                                                                 parameter.ParameterType != UnwrappedBatchType &&
                                                                  parameter.ParameterType.GetGenericTypeDefinition() ==
                                                                  TypedBatchType;
 


### PR DESCRIPTION
Fix for subscription handler validation when using a mix of `IReadOnlyList<IMessageContext>` and `IReadOnlyList<SomeEvent>`