### PR TITLE
Replay - subscription initialization fix

### DIFF
--- a/src/Beckett/Subscriptions/Queries/GetSubscriptionCheckpointCount.cs
+++ b/src/Beckett/Subscriptions/Queries/GetSubscriptionCheckpointCount.cs
@@ -1,0 +1,41 @@
+using Beckett.Database;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace Beckett.Subscriptions.Queries;
+
+public class GetSubscriptionCheckpointCount(
+    string groupName,
+    string name,
+    PostgresOptions options
+) : IPostgresDatabaseQuery<long>
+{
+    public async Task<long> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
+    {
+        command.CommandText = $@"
+            SELECT count(*)
+            FROM {options.Schema}.checkpoints
+            WHERE group_name = $1
+            AND name = $2;
+        ";
+
+        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
+        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
+
+        if (options.PrepareStatements)
+        {
+            await command.PrepareAsync(cancellationToken);
+        }
+
+        command.Parameters[0].Value = groupName;
+        command.Parameters[0].Value = name;
+
+        var result = await command.ExecuteScalarAsync(cancellationToken);
+
+        return result switch
+        {
+            long count => count,
+            _ => throw new Exception($"Unexpected result from subscription checkpoint count: {result}")
+        };
+    }
+}


### PR DESCRIPTION
- fix to handle new subscriptions that don't have any work to do after initialization - instead of being stuck in replay they should be set to active