### PR TITLE
Replay fixes, individual subscription batch size support

### DIFF
--- a/db/versions/0.20.1.sql
+++ b/db/versions/0.20.1.sql
@@ -1,0 +1,87 @@
+-- Beckett v0.20.1 - replay updates
+CREATE TYPE beckett.stream_message AS
+(
+  id uuid,
+  stream_name text,
+  stream_position bigint,
+  global_position bigint,
+  type text,
+  data jsonb,
+  metadata jsonb,
+  timestamp timestamp with time zone
+);
+
+CREATE TYPE beckett.read_global_stream_result AS
+(
+  messages beckett.stream_message[],
+  ending_global_position bigint
+);
+
+DROP FUNCTION beckett.read_global_stream(bigint, int, text, text[]);
+
+CREATE OR REPLACE FUNCTION beckett.read_global_stream(
+  _starting_global_position bigint,
+  _count int,
+  _category text DEFAULT NULL,
+  _types text[] DEFAULT NULL
+)
+  RETURNS beckett.read_global_stream_result
+  LANGUAGE plpgsql
+AS
+$$
+DECLARE
+  _transaction_id xid8;
+  _result beckett.read_global_stream_result;
+BEGIN
+  SELECT m.transaction_id
+  INTO _transaction_id
+  FROM beckett.messages m
+  WHERE m.global_position = _starting_global_position
+  AND m.archived = false;
+
+  IF (_transaction_id IS NULL) THEN
+    _transaction_id = '0'::xid8;
+  END IF;
+
+  WITH batch AS (
+    SELECT m.id, m.global_position, m.transaction_id
+    FROM beckett.messages m
+    WHERE (m.transaction_id, m.global_position) > (_transaction_id, _starting_global_position)
+    AND m.transaction_id < pg_snapshot_xmin(pg_current_snapshot())
+    AND m.archived = false
+    ORDER BY m.transaction_id, m.global_position
+    LIMIT _count
+  ),
+  ending_global_position AS (
+    SELECT b.global_position
+    FROM batch b
+    ORDER BY b.transaction_id DESC, b.global_position DESC
+    LIMIT 1
+  ),
+  results AS (
+    SELECT m.id,
+           m.stream_name,
+           m.stream_position,
+           m.global_position,
+           m.type,
+           m.data,
+           m.metadata,
+           m.timestamp
+    FROM beckett.messages m
+    INNER JOIN batch b ON m.id = b.id
+    WHERE m.archived = FALSE
+    AND (_category IS NULL OR beckett.stream_category(m.stream_name) = _category)
+    AND (_types IS NULL OR m.type = ANY (_types))
+    ORDER BY m.transaction_id, m.global_position
+  )
+  SELECT array_agg(r.*), (SELECT global_position FROM ending_global_position)
+  INTO _result.messages, _result.ending_global_position
+  FROM results r;
+
+  IF (_result.messages IS NULL) THEN
+    _result.messages := ARRAY[]::beckett.stream_message[];
+  END IF;
+
+  RETURN _result;
+END;
+$$;

--- a/src/Beckett.Tests/Subscriptions/CheckpointProcessorTests.cs
+++ b/src/Beckett.Tests/Subscriptions/CheckpointProcessorTests.cs
@@ -22,7 +22,7 @@ public class CheckpointProcessorTests
                 var options = new BeckettOptions();
                 var group = options.WithSubscriptionGroup(
                     Guid.NewGuid().ToString(),
-                    x => x.SubscriptionStreamBatchSize = 10
+                    x => x.SubscriptionBatchSize = 10
                 );
                 var checkpoint = new Checkpoint(1, group.Name, "test", "test", 0, 10, 0, CheckpointStatus.Active);
                 var subscription = new Subscription(group, "test")
@@ -52,7 +52,7 @@ public class CheckpointProcessorTests
                 var options = new BeckettOptions();
                 var group = options.WithSubscriptionGroup(
                     Guid.NewGuid().ToString(),
-                    x => x.SubscriptionStreamBatchSize = 10
+                    x => x.SubscriptionBatchSize = 10
                 );
                 var checkpoint = new Checkpoint(1, group.Name, "test", "test", 0, 20, 0, CheckpointStatus.Active);
                 var subscription = new Subscription(group, "test")
@@ -157,7 +157,7 @@ public class CheckpointProcessorTests
                 var options = new BeckettOptions();
                 var group = options.WithSubscriptionGroup(
                     Guid.NewGuid().ToString(),
-                    x => x.SubscriptionStreamBatchSize = 10
+                    x => x.SubscriptionBatchSize = 10
                 );
                 var checkpoint = new Checkpoint(1, group.Name, "test", "test", 1, 20, 0, CheckpointStatus.Retry);
                 var subscription = new Subscription(group, "test")
@@ -264,7 +264,7 @@ public class CheckpointProcessorTests
                     var options = new BeckettOptions();
                     var group = options.WithSubscriptionGroup(
                         Guid.NewGuid().ToString(),
-                        x => x.SubscriptionStreamBatchSize = 10
+                        x => x.SubscriptionBatchSize = 10
                     );
                     var checkpoint = new Checkpoint(1, group.Name, "test", "test", 1, 10, 0, CheckpointStatus.Retry);
                     var subscription = new Subscription(group, "test")
@@ -294,7 +294,7 @@ public class CheckpointProcessorTests
                     var options = new BeckettOptions();
                     var group = options.WithSubscriptionGroup(
                         Guid.NewGuid().ToString(),
-                        x => x.SubscriptionStreamBatchSize = 10
+                        x => x.SubscriptionBatchSize = 10
                     );
                     var checkpoint = new Checkpoint(1, group.Name, "test", "test", 1, 20, 0, CheckpointStatus.Retry);
                     var subscription = new Subscription(group, "test")

--- a/src/Beckett/Database/NpgsqlDataSourceBuilderExtensions.cs
+++ b/src/Beckett/Database/NpgsqlDataSourceBuilderExtensions.cs
@@ -15,6 +15,7 @@ public static class NpgsqlDataSourceBuilderExtensions
         builder.MapComposite<MessageType>(DataTypeNames.Message(schema));
         builder.MapComposite<RetryType>(DataTypeNames.Retry(schema));
         builder.MapComposite<ScheduledMessageType>(DataTypeNames.ScheduledMessage(schema));
+        builder.MapComposite<StreamMessageType>(DataTypeNames.StreamMessage(schema));
 
         builder.MapEnum<CheckpointStatus>(DataTypeNames.CheckpointStatus(schema));
         builder.MapEnum<SubscriptionStatus>(DataTypeNames.SubscriptionStatus(schema));

--- a/src/Beckett/Database/Types/DataTypeNames.cs
+++ b/src/Beckett/Database/Types/DataTypeNames.cs
@@ -12,6 +12,8 @@ public static class DataTypeNames
 
     public static string MessageArray(string schema) => $"{schema}.message[]";
 
+    public static string StreamMessage(string schema) => $"{schema}.stream_message";
+
     public static string Retry(string schema) => $"{schema}.retry";
 
     public static string ScheduledMessage(string schema) => $"{schema}.scheduled_message";

--- a/src/Beckett/Database/Types/StreamMessageType.cs
+++ b/src/Beckett/Database/Types/StreamMessageType.cs
@@ -1,9 +1,9 @@
 using System.Text.Json;
 using Npgsql;
 
-namespace Beckett.Database.Models;
+namespace Beckett.Database.Types;
 
-public class PostgresMessage
+public class StreamMessageType
 {
     public required Guid Id { get; init; }
     public required string StreamName { get; init; }
@@ -15,12 +15,12 @@ public class PostgresMessage
     public required JsonElement Metadata { get; init; }
     public required DateTimeOffset Timestamp { get; init; }
 
-    public static PostgresMessage From(NpgsqlDataReader reader)
+    public static StreamMessageType From(NpgsqlDataReader reader)
     {
         using var data = reader.GetFieldValue<JsonDocument>(6);
         using var metadata = reader.GetFieldValue<JsonDocument>(7);
 
-        return new PostgresMessage
+        return new StreamMessageType
         {
             Id = reader.GetFieldValue<Guid>(0),
             StreamName = reader.GetFieldValue<string>(1),

--- a/src/Beckett/Storage/InMemory/InMemoryMessageStorage.cs
+++ b/src/Beckett/Storage/InMemory/InMemoryMessageStorage.cs
@@ -105,7 +105,9 @@ public class InMemoryMessageStorage : IMessageStorage
             messages = messages.Where(x => options.Types.Contains(x.Type)).ToList();
         }
 
-        return Task.FromResult(new ReadGlobalStreamResult(messages));
+        var globalPosition = messages.Count == 0 ? 0 : messages.Last().GlobalPosition;
+
+        return Task.FromResult(new ReadGlobalStreamResult(messages, globalPosition));
     }
 
     public Task<ReadStreamResult> ReadStream(

--- a/src/Beckett/Storage/Postgres/Queries/ReadStream.cs
+++ b/src/Beckett/Storage/Postgres/Queries/ReadStream.cs
@@ -1,5 +1,5 @@
 using Beckett.Database;
-using Beckett.Database.Models;
+using Beckett.Database.Types;
 using Npgsql;
 using NpgsqlTypes;
 
@@ -9,9 +9,9 @@ public class ReadStream(
     string streamName,
     ReadStreamOptions readOptions,
     PostgresOptions postgresOptions
-) : IPostgresDatabaseQuery<IReadOnlyList<PostgresMessage>>
+) : IPostgresDatabaseQuery<IReadOnlyList<StreamMessageType>>
 {
-    public async Task<IReadOnlyList<PostgresMessage>> Execute(
+    public async Task<IReadOnlyList<StreamMessageType>> Execute(
         NpgsqlCommand command,
         CancellationToken cancellationToken
     )
@@ -64,11 +64,11 @@ public class ReadStream(
 
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
 
-        var results = new List<PostgresMessage>();
+        var results = new List<StreamMessageType>();
 
         while (await reader.ReadAsync(cancellationToken))
         {
-            results.Add(PostgresMessage.From(reader));
+            results.Add(StreamMessageType.From(reader));
         }
 
         return results;

--- a/src/Beckett/Storage/ReadGlobalStreamResult.cs
+++ b/src/Beckett/Storage/ReadGlobalStreamResult.cs
@@ -1,3 +1,3 @@
 namespace Beckett.Storage;
 
-public record ReadGlobalStreamResult(IReadOnlyList<StreamMessage> StreamMessages);
+public record ReadGlobalStreamResult(IReadOnlyList<StreamMessage> StreamMessages, long GlobalPosition);

--- a/src/Beckett/Subscriptions/CheckpointConsumer.cs
+++ b/src/Beckett/Subscriptions/CheckpointConsumer.cs
@@ -68,6 +68,11 @@ public class CheckpointConsumer(
                         instance
                     );
 
+                    await database.Execute(
+                        new ReleaseCheckpointReservation(checkpoint.Id, options.Postgres),
+                        CancellationToken.None
+                    );
+
                     continue;
                 }
 

--- a/src/Beckett/Subscriptions/Configuration/ISubscriptionConfigurationBuilder.cs
+++ b/src/Beckett/Subscriptions/Configuration/ISubscriptionConfigurationBuilder.cs
@@ -107,13 +107,19 @@ public interface ISubscriptionConfigurationBuilder
     ISubscriptionConfigurationBuilder StartingPosition(StartingPosition startingPosition);
 
     /// <summary>
+    /// Configure the subscription batch size, overriding the default batch size configured for the group
+    /// </summary>
+    /// <param name="batchSize">Batch size for the subscription</param>
+    /// <returns>Builder to further configure the subscription</returns>
+    ISubscriptionConfigurationBuilder BatchSize(int batchSize);
+
+    /// <summary>
     /// Configure the subscription to partition checkpoints by stream. Checkpoints will be tracked for each stream
     /// that matches the subscription configuration and processed in parallel based on the concurrency level configured
     /// for the group the subscription belongs to.
     /// </summary>
     /// <returns>Builder to further configure the subscription</returns>
     ISubscriptionConfigurationBuilder PartitionByStream();
-
     /// <summary>
     /// Configure the subscription to track a single checkpoint based on the global stream. Messages will be processed
     /// in global order in batches using the configured batch size.

--- a/src/Beckett/Subscriptions/Configuration/SubscriptionConfigurationBuilder.cs
+++ b/src/Beckett/Subscriptions/Configuration/SubscriptionConfigurationBuilder.cs
@@ -81,6 +81,21 @@ public class SubscriptionConfigurationBuilder(
         return this;
     }
 
+    public ISubscriptionConfigurationBuilder BatchSize(int batchSize)
+    {
+        if (batchSize < 1)
+        {
+            throw new ArgumentException(
+                "The batch size must be greater than or equal to 1",
+                nameof(batchSize)
+            );
+        }
+
+        subscription.BatchSize = batchSize;
+
+        return this;
+    }
+
     public ISubscriptionConfigurationBuilder PartitionByStream()
     {
         subscription.PartitionStrategy = PerStreamPartitionStrategy.Instance;

--- a/src/Beckett/Subscriptions/Subscription.cs
+++ b/src/Beckett/Subscriptions/Subscription.cs
@@ -16,6 +16,7 @@ public class Subscription(SubscriptionGroup group, string name)
     internal string? HandlerName { get; set; }
     internal StartingPosition StartingPosition { get; set; } = StartingPosition.Latest;
     internal IPartitionStrategy PartitionStrategy { get; set; } = PerStreamPartitionStrategy.Instance;
+    internal int? BatchSize { get; set; }
     internal Dictionary<Type, int> MaxRetriesByExceptionType { get; } = [];
     internal int Priority { get; set; } = int.MaxValue;
     internal bool SkipDuringReplay { get; set; }

--- a/src/Beckett/Subscriptions/SubscriptionGroup.cs
+++ b/src/Beckett/Subscriptions/SubscriptionGroup.cs
@@ -57,7 +57,7 @@ public class SubscriptionGroup(string groupName)
     /// subscription Beckett will keep reading batches of messages from the stream and processing them until there are
     /// none left.
     /// </summary>
-    public int SubscriptionStreamBatchSize { get; set; } = 500;
+    public int SubscriptionBatchSize { get; set; } = 500;
 
     /// <summary>
     /// Configure the polling interval to check for new checkpoints to process. When Postgres notifications are enabled


### PR DESCRIPTION
- replay fixes - global stream read needed to return the actual upper bounds of the ending global position it read to _before_ filtering by category or type
- subscriptions can now be configured with a batch size which overrides the group batch size