### PR TITLE
Reinstate batch handler support

### DIFF
--- a/src/Beckett.Tests/Storage/InMemory/InMemoryMessageStorageTests.cs
+++ b/src/Beckett.Tests/Storage/InMemory/InMemoryMessageStorageTests.cs
@@ -42,7 +42,7 @@ public class InMemoryMessageStorageTests
             BatchSize = 10
         }, CancellationToken.None);
 
-        var item = Assert.Single(globalStream.Messages);
+        var item = Assert.Single(globalStream.StreamMessages);
         Assert.Equal(1, item.GlobalPosition);
         Assert.Equal(1, item.StreamPosition);
         Assert.Equal(streamName, item.StreamName);

--- a/src/Beckett.Tests/Subscriptions/SubscriptionHandlerTests.cs
+++ b/src/Beckett.Tests/Subscriptions/SubscriptionHandlerTests.cs
@@ -32,6 +32,7 @@ public class SubscriptionHandlerTests
 
         await handler.Invoke(messageContext, subscriptionContext, _serviceProvider, _logger, CancellationToken.None);
 
+        Assert.False(handler.IsBatchHandler);
         Assert.NotNull(MessageContextHandler.ReceivedContext);
         Assert.Equal(messageContext, MessageContextHandler.ReceivedContext);
     }
@@ -46,6 +47,7 @@ public class SubscriptionHandlerTests
 
         await handler.Invoke(messageContext, subscriptionContext, _serviceProvider, _logger, CancellationToken.None);
 
+        Assert.False(handler.IsBatchHandler);
         Assert.NotNull(SubscriptionContextHandler.ReceivedContext);
         Assert.Equal(subscriptionContext, SubscriptionContextHandler.ReceivedContext);
     }
@@ -61,6 +63,7 @@ public class SubscriptionHandlerTests
 
         await handler.Invoke(messageContext, subscriptionContext, _serviceProvider, _logger, CancellationToken.None);
 
+        Assert.False(handler.IsBatchHandler);
         Assert.NotNull(MessageHandler.ReceivedMessage);
         Assert.Equal(message, MessageHandler.ReceivedMessage);
     }
@@ -77,6 +80,7 @@ public class SubscriptionHandlerTests
 
         await handler.Invoke(typedContext, subscriptionContext, _serviceProvider, _logger, CancellationToken.None);
 
+        Assert.False(handler.IsBatchHandler);
         Assert.NotNull(TypedMessageContextHandler.ReceivedMessage);
         Assert.Equal(message, TypedMessageContextHandler.ReceivedMessage);
     }
@@ -92,10 +96,74 @@ public class SubscriptionHandlerTests
 
         await handler.Invoke(messageContext, subscriptionContext, _serviceProvider, _logger, CancellationToken.None);
 
+        Assert.False(handler.IsBatchHandler);
         Assert.NotNull(MessageAndContextHandler.ReceivedMessage);
         Assert.NotNull(MessageAndContextHandler.ReceivedContext);
         Assert.Equal(message, MessageAndContextHandler.ReceivedMessage);
         Assert.Equal(messageContext, MessageAndContextHandler.ReceivedContext);
+    }
+
+    [Fact]
+    public async Task supports_batch_handler()
+    {
+        _subscription.RegisterMessageType<TestMessage>();
+        var handler = new SubscriptionHandler(_subscription, BatchHandler.Handle);
+        var batch = BuildMessageBatch();
+        var subscriptionContext = BuildSubscriptionContext();
+
+        await handler.Invoke(batch, subscriptionContext, _serviceProvider, _logger, CancellationToken.None);
+
+        Assert.True(handler.IsBatchHandler);
+        Assert.NotNull(BatchHandler.ReceivedBatch);
+        Assert.Equal(batch, BatchHandler.ReceivedBatch);
+    }
+
+    [Fact]
+    public async Task supports_batch_handler_with_multiple_message_types()
+    {
+        _subscription.RegisterMessageType<TestMessage>();
+        _subscription.RegisterMessageType<AnotherTestMessage>();
+        var handler = new SubscriptionHandler(_subscription, BatchHandler.Handle);
+        var batch = BuildMessageBatch();
+        var subscriptionContext = BuildSubscriptionContext();
+
+        await handler.Invoke(batch, subscriptionContext, _serviceProvider, _logger, CancellationToken.None);
+
+        Assert.True(handler.IsBatchHandler);
+        Assert.NotNull(BatchHandler.ReceivedBatch);
+        Assert.Equal(batch, BatchHandler.ReceivedBatch);
+    }
+
+    [Fact]
+    public async Task supports_typed_batch_handler()
+    {
+        _subscription.RegisterMessageType<TestMessage>();
+        var handler = new SubscriptionHandler(_subscription, TypedBatchHandler.Handle);
+        var batch = BuildMessageBatch();
+        var subscriptionContext = BuildSubscriptionContext();
+        var expectedBatch = batch.Select(x => x.Message).Cast<TestMessage>().ToList();
+
+        await handler.Invoke(batch, subscriptionContext, _serviceProvider, _logger, CancellationToken.None);
+
+        Assert.True(handler.IsBatchHandler);
+        Assert.NotNull(TypedBatchHandler.ReceivedBatch);
+        Assert.Equal(expectedBatch, TypedBatchHandler.ReceivedBatch);
+    }
+
+    [Fact]
+    public async Task supports_unwrapped_batch_handler()
+    {
+        _subscription.RegisterMessageType<TestMessage>();
+        var handler = new SubscriptionHandler(_subscription, UnwrappedBatchHandler.Handle);
+        var batch = BuildMessageBatch();
+        var subscriptionContext = BuildSubscriptionContext();
+        var expectedBatch = batch.Select(x => x.Message!).ToList();
+
+        await handler.Invoke(batch, subscriptionContext, _serviceProvider, _logger, CancellationToken.None);
+
+        Assert.True(handler.IsBatchHandler);
+        Assert.NotNull(UnwrappedBatchHandler.ReceivedBatch);
+        Assert.Equal(expectedBatch, UnwrappedBatchHandler.ReceivedBatch);
     }
 
     [Fact]
@@ -217,12 +285,47 @@ public class SubscriptionHandlerTests
     }
 
     [Fact]
+    public void handlers_can_only_accept_messages_or_batches_not_both()
+    {
+        Assert.Throws<InvalidOperationException>(() => new SubscriptionHandler(
+                _subscription,
+                InvalidHandlerWithContextAndBatch.Handle
+            )
+        );
+    }
+
+    [Fact]
     public void typed_handlers_cannot_accept_multiple_message_types()
     {
         _subscription.RegisterMessageType<TestMessage>();
         _subscription.RegisterMessageType<AnotherTestMessage>();
 
         Assert.Throws<InvalidOperationException>(() => new SubscriptionHandler(_subscription, MessageHandler.Handle));
+    }
+
+    [Fact]
+    public void typed_batch_handlers_cannot_accept_multiple_message_types()
+    {
+        _subscription.RegisterMessageType<TestMessage>();
+        _subscription.RegisterMessageType<AnotherTestMessage>();
+
+        Assert.Throws<InvalidOperationException>(() => new SubscriptionHandler(
+                _subscription,
+                TypedBatchHandler.Handle
+            )
+        );
+    }
+
+    [Fact]
+    public void batch_handlers_cannot_also_handle_messages()
+    {
+        _subscription.RegisterMessageType<TestMessage>();
+
+        Assert.Throws<InvalidOperationException>(() => new SubscriptionHandler(
+                _subscription,
+                InvalidHandlerWithBatchAndMessage.Handle
+            )
+        );
     }
 
     [Fact]
@@ -291,6 +394,20 @@ public class SubscriptionHandlerTests
         DateTimeOffset.UtcNow
     );
 
+    private static IReadOnlyList<IMessageContext> BuildMessageBatch() =>
+    [
+        new MessageContext(
+            Guid.NewGuid().ToString(),
+            "test-123",
+            1,
+            1,
+            "test-message",
+            EmptyJsonElement.Instance,
+            EmptyJsonElement.Instance,
+            DateTimeOffset.UtcNow
+        )
+    ];
+
     private static class MessageContextHandler
     {
         public static IMessageContext? ReceivedContext { get; private set; }
@@ -353,6 +470,42 @@ public class SubscriptionHandlerTests
         }
     }
 
+    private static class BatchHandler
+    {
+        public static IReadOnlyList<IMessageContext>? ReceivedBatch { get; private set; }
+
+        public static Task Handle(IReadOnlyList<IMessageContext> batch, CancellationToken cancellationToken)
+        {
+            ReceivedBatch = batch;
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private static class TypedBatchHandler
+    {
+        public static IReadOnlyList<TestMessage>? ReceivedBatch { get; private set; }
+
+        public static Task Handle(IReadOnlyList<TestMessage> batch, CancellationToken cancellationToken)
+        {
+            ReceivedBatch = batch;
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private static class UnwrappedBatchHandler
+    {
+        public static IReadOnlyList<object>? ReceivedBatch { get; private set; }
+
+        public static Task Handle(IReadOnlyList<object> batch, CancellationToken cancellationToken)
+        {
+            ReceivedBatch = batch;
+
+            return Task.CompletedTask;
+        }
+    }
+
     private static class HandlerWithDependencies
     {
         public static Task Handle(IMessageContext context, ITestService service, CancellationToken cancellationToken)
@@ -395,6 +548,30 @@ public class SubscriptionHandlerTests
     {
         public static void Handle(IMessageContext context)
         {
+        }
+    }
+
+    private static class InvalidHandlerWithContextAndBatch
+    {
+        public static Task Handle(
+            IMessageContext context,
+            IReadOnlyList<IMessageContext> batch,
+            CancellationToken cancellationToken
+        )
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    private static class InvalidHandlerWithBatchAndMessage
+    {
+        public static Task Handle(
+            IReadOnlyList<IMessageContext> batch,
+            TestMessage message,
+            CancellationToken cancellationToken
+        )
+        {
+            return Task.CompletedTask;
         }
     }
 

--- a/src/Beckett/Storage/ReadGlobalStreamResult.cs
+++ b/src/Beckett/Storage/ReadGlobalStreamResult.cs
@@ -1,3 +1,3 @@
 namespace Beckett.Storage;
 
-public record ReadGlobalStreamResult(IReadOnlyList<GlobalStreamMessage> Messages);
+public record ReadGlobalStreamResult(IReadOnlyList<GlobalStreamMessage> StreamMessages);

--- a/src/Beckett/Subscriptions/BatchHandlerException.cs
+++ b/src/Beckett/Subscriptions/BatchHandlerException.cs
@@ -1,0 +1,12 @@
+namespace Beckett.Subscriptions;
+
+/// <summary>
+/// Exception that subscription batch handlers can throw to tell Beckett the stream position of the message which
+/// caused an error.
+/// </summary>
+/// <param name="streamPosition">The stream position of the failed message</param>
+/// <param name="exception">Error that occurred</param>
+public class BatchHandlerException(long streamPosition, Exception exception) : Exception(null, exception)
+{
+    public long StreamPosition => streamPosition;
+}

--- a/src/Beckett/Subscriptions/GlobalStreamConsumer.cs
+++ b/src/Beckett/Subscriptions/GlobalStreamConsumer.cs
@@ -63,18 +63,18 @@ public class GlobalStreamConsumer(
                     stoppingToken
                 );
 
-                if (batch.Messages.Count == 0)
+                if (batch.StreamMessages.Count == 0)
                 {
                     logger.NoNewGlobalStreamMessagesFoundAfterPosition(checkpoint.StreamPosition);
 
                     continue;
                 }
 
-                logger.NewGlobalStreamMessagesToProcess(batch.Messages.Count, checkpoint.StreamPosition);
+                logger.NewGlobalStreamMessagesToProcess(batch.StreamMessages.Count, checkpoint.StreamPosition);
 
                 var checkpoints = new HashSet<CheckpointType>(CheckpointType.Comparer);
 
-                foreach (var stream in batch.Messages.GroupBy(x => x.StreamName))
+                foreach (var stream in batch.StreamMessages.GroupBy(x => x.StreamName))
                 {
                     var subscriptions = registeredSubscriptions
                         .Where(subscription => stream.Any(m => m.AppliesTo(subscription)))
@@ -118,7 +118,7 @@ public class GlobalStreamConsumer(
                     logger.NoNewCheckpointsToRecord();
                 }
 
-                var newGlobalPosition = batch.Messages.Max(x => x.GlobalPosition);
+                var newGlobalPosition = batch.StreamMessages.Max(x => x.GlobalPosition);
 
                 await database.Execute(
                     new UpdateSystemCheckpointPosition(checkpoint.Id, newGlobalPosition, postgresOptions),
@@ -153,7 +153,7 @@ public class GlobalStreamConsumer(
         var categories = new Dictionary<string, DateTimeOffset>();
         var tenants = new HashSet<string>();
 
-        foreach (var message in globalStream.Messages)
+        foreach (var message in globalStream.StreamMessages)
         {
             categories[StreamCategoryParser.Parse(message.StreamName)] = message.Timestamp;
 

--- a/src/Beckett/Subscriptions/Initialization/SubscriptionInitializer.cs
+++ b/src/Beckett/Subscriptions/Initialization/SubscriptionInitializer.cs
@@ -106,7 +106,7 @@ public class SubscriptionInitializer(
                 cancellationToken
             );
 
-            if (batch.Messages.Count == 0)
+            if (batch.StreamMessages.Count == 0)
             {
                 var globalCheckpoint = await database.Execute(
                     new LockCheckpoint(
@@ -134,7 +134,7 @@ public class SubscriptionInitializer(
                     cancellationToken
                 );
 
-                if (nextBatch.Messages.Any())
+                if (nextBatch.StreamMessages.Any())
                 {
                     continue;
                 }
@@ -203,7 +203,7 @@ public class SubscriptionInitializer(
 
             var checkpoints = new List<CheckpointType>();
 
-            foreach (var stream in batch.Messages.GroupBy(x => x.StreamName))
+            foreach (var stream in batch.StreamMessages.GroupBy(x => x.StreamName))
             {
                 if (stream.All(x => !x.AppliesTo(subscription)))
                 {
@@ -234,7 +234,7 @@ public class SubscriptionInitializer(
                 cancellationToken
             );
 
-            var newGlobalPosition = batch.Messages.Max(x => x.GlobalPosition);
+            var newGlobalPosition = batch.StreamMessages.Max(x => x.GlobalPosition);
 
             await database.Execute(
                 new UpdateSystemCheckpointPosition(


### PR DESCRIPTION
- after discussing it we'll keep batch support, but only at the stream-level, with the idea that applications can throw `BatchHandlerException` to communicate the stream position where the error occurred