### PR TITLE
Stream batch handling updates

### DIFF
--- a/src/Beckett/Database/Models/PostgresStreamMessage.cs
+++ b/src/Beckett/Database/Models/PostgresStreamMessage.cs
@@ -7,7 +7,6 @@ public class PostgresStreamMessage
 {
     public required Guid Id { get; init; }
     public required string StreamName { get; init; }
-    public required long StreamVersion { get; init; }
     public required long StreamPosition { get; init; }
     public required long GlobalPosition { get; init; }
     public required string Type { get; init; }
@@ -22,9 +21,8 @@ public class PostgresStreamMessage
 
         return new PostgresStreamMessage
         {
-            Id = reader.GetFieldValue<Guid>(0),
-            StreamName = reader.GetFieldValue<string>(1),
-            StreamVersion = reader.GetFieldValue<long>(2),
+            Id = reader.GetFieldValue<Guid>(1),
+            StreamName = reader.GetFieldValue<string>(2),
             StreamPosition = reader.GetFieldValue<long>(3),
             GlobalPosition = reader.GetFieldValue<long>(4),
             Type = reader.GetFieldValue<string>(5),

--- a/src/Beckett/IMessageStream.cs
+++ b/src/Beckett/IMessageStream.cs
@@ -123,8 +123,8 @@ public class MessageStream(
     public IReadOnlyList<object> Messages =>
         StreamMessages.Where(x => x.Message != null).Select(x => x.Message!).ToList();
 
-    public bool IsEmpty => StreamMessages.Count == 0;
-    public bool IsNotEmpty => StreamMessages.Count > 0;
+    public bool IsEmpty => StreamVersion == 0;
+    public bool IsNotEmpty => StreamVersion > 0;
 
     public Task<IAppendResult> Append(
         IEnumerable<Message> messages,

--- a/src/Beckett/Storage/Postgres/PostgresMessageStorage.cs
+++ b/src/Beckett/Storage/Postgres/PostgresMessageStorage.cs
@@ -74,16 +74,14 @@ public class PostgresMessageStorage(IPostgresDataSource dataSource, IPostgresDat
 
         await connection.OpenAsync(cancellationToken);
 
-        var streamMessages = await database.Execute(
+        var result = await database.Execute(
             new ReadStream(streamName, readOptions, options),
             cancellationToken
         );
 
-        var streamVersion = streamMessages.Count == 0 ? 0 : streamMessages[0].StreamVersion;
-
         var messages = new List<StreamMessage>();
 
-        foreach (var streamMessage in streamMessages)
+        foreach (var streamMessage in result.StreamMessages)
         {
             messages.Add(
                 new StreamMessage(
@@ -99,6 +97,6 @@ public class PostgresMessageStorage(IPostgresDataSource dataSource, IPostgresDat
             );
         }
 
-        return new ReadStreamResult(streamName, streamVersion, messages);
+        return new ReadStreamResult(streamName, result.StreamVersion, messages);
     }
 }


### PR DESCRIPTION
- read stream should always return the stream version even if it is being filtered by type, etc...
- checkpoint processing needs to take the stream version into account to handle batching scenarios correctly
  - stream has 1500 messages, batch size 500, filtering by type means the first two batches don't return any messages, but the checkpoint needs to advance regardless
- update Is(Not)Empty on message stream to be based on the stream version, not whether messages were returned to handle filtered batch scenarios