### PR TITLE
SQL handling updates

### DIFF
--- a/src/Beckett.Dashboard/Home/Index.razor
+++ b/src/Beckett.Dashboard/Home/Index.razor
@@ -2,7 +2,6 @@
 @using Beckett.Database
 @layout Layout
 @inject IPostgresDatabase Database
-@inject PostgresOptions PostgresOptions
 
 <div id="metrics" class="row mt-4 mx-2" hx-get="@Dashboard.Prefix/" hx-trigger="every 10s" hx-select="#metrics"
      hx-swap="outerHTML">
@@ -46,7 +45,7 @@
 
   protected override async Task OnInitializedAsync()
   {
-    var result = await Database.Execute(new MetricsQuery(PostgresOptions), CancellationToken.None);
+    var result = await Database.Execute(new MetricsQuery(), CancellationToken.None);
 
     Model = new ViewModel(result.Lagging, result.Retries, result.Failed);
   }

--- a/src/Beckett.Dashboard/MessageStore/Categories/CategoriesEndpoint.cs
+++ b/src/Beckett.Dashboard/MessageStore/Categories/CategoriesEndpoint.cs
@@ -19,7 +19,7 @@ public static class CategoriesEndpoint
         var offset = Pagination.ToOffset(pageParameter, pageSizeParameter);
 
         var result = await database.Execute(
-            new CategoriesQuery(query, offset, pageSizeParameter, options),
+            new CategoriesQuery(query, offset, pageSizeParameter),
             cancellationToken
         );
 

--- a/src/Beckett.Dashboard/MessageStore/Categories/CategoriesQuery.cs
+++ b/src/Beckett.Dashboard/MessageStore/Categories/CategoriesQuery.cs
@@ -12,6 +12,7 @@ public class CategoriesQuery(
 {
     public async Task<Result> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
            SELECT name,
                   updated_at,

--- a/src/Beckett.Dashboard/MessageStore/Components/Queries/TenantsQuery.cs
+++ b/src/Beckett.Dashboard/MessageStore/Components/Queries/TenantsQuery.cs
@@ -7,6 +7,7 @@ public class TenantsQuery : IPostgresDatabaseQuery<TenantsQuery.Result>
 {
     public async Task<Result> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = "SELECT tenant FROM beckett.tenants ORDER BY tenant;";
 
         command.CommandText = Query.Build(nameof(TenantsQuery), sql, out var prepare);

--- a/src/Beckett.Dashboard/MessageStore/Components/Queries/TenantsQuery.cs
+++ b/src/Beckett.Dashboard/MessageStore/Components/Queries/TenantsQuery.cs
@@ -3,11 +3,18 @@ using Npgsql;
 
 namespace Beckett.Dashboard.MessageStore.Components.Queries;
 
-public class TenantsQuery(PostgresOptions options) : IPostgresDatabaseQuery<TenantsQuery.Result>
+public class TenantsQuery : IPostgresDatabaseQuery<TenantsQuery.Result>
 {
     public async Task<Result> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
-        command.CommandText = $"SELECT tenant FROM {options.Schema}.tenants ORDER BY tenant;";
+        const string sql = "SELECT tenant FROM beckett.tenants ORDER BY tenant;";
+
+        command.CommandText = Query.Build(nameof(TenantsQuery), sql, out var prepare);
+
+        if (prepare)
+        {
+            await command.PrepareAsync(cancellationToken);
+        }
 
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
 

--- a/src/Beckett.Dashboard/MessageStore/Components/TenantFilter.razor
+++ b/src/Beckett.Dashboard/MessageStore/Components/TenantFilter.razor
@@ -2,7 +2,6 @@
 @using Beckett.Database
 @inherits Component<TenantFilter.ViewModel>
 @inject IPostgresDatabase Database
-@inject PostgresOptions PostgresOptions
 
 <form id="tenantFilter" class="d-flex input-group w-auto me-2" method="GET">
   <span class="input-group-text" for="tenant">
@@ -67,7 +66,7 @@
 
   protected override async Task OnInitializedAsync()
   {
-    var result = await Database.Execute(new TenantsQuery(PostgresOptions), CancellationToken.None);
+    var result = await Database.Execute(new TenantsQuery(), CancellationToken.None);
 
     if (result.Tenants.Count == 0)
     {

--- a/src/Beckett.Dashboard/MessageStore/CorrelatedBy/CorrelatedByEndpoint.cs
+++ b/src/Beckett.Dashboard/MessageStore/CorrelatedBy/CorrelatedByEndpoint.cs
@@ -19,7 +19,7 @@ public static class CorrelatedByEndpoint
         var offset = Pagination.ToOffset(pageParameter, pageSizeParameter);
 
         var result = await database.Execute(
-            new CorrelatedMessagesQuery(correlationId, query, offset, pageSizeParameter, options),
+            new CorrelatedMessagesQuery(correlationId, query, offset, pageSizeParameter),
             cancellationToken
         );
 

--- a/src/Beckett.Dashboard/MessageStore/CorrelatedBy/CorrelatedMessagesQuery.cs
+++ b/src/Beckett.Dashboard/MessageStore/CorrelatedBy/CorrelatedMessagesQuery.cs
@@ -13,6 +13,7 @@ public class CorrelatedMessagesQuery(
 {
     public async Task<Result> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
            SELECT id, stream_name, stream_position, type, timestamp, count(*) over() AS total_results
            FROM beckett.messages

--- a/src/Beckett.Dashboard/MessageStore/Message/MessageByIdEndpoint.cs
+++ b/src/Beckett.Dashboard/MessageStore/Message/MessageByIdEndpoint.cs
@@ -16,7 +16,7 @@ public static class MessageByIdEndpoint
             throw new InvalidOperationException("Invalid message ID");
         }
 
-        var result = await database.Execute(new MessageQuery(guid, options), cancellationToken);
+        var result = await database.Execute(new MessageQuery(guid), cancellationToken);
 
         return result is null ? Results.NotFound() : Results.Extensions.Render<Message>(new Message.ViewModel(result));
     }

--- a/src/Beckett.Dashboard/MessageStore/Message/MessageByStreamPositionEndpoint.cs
+++ b/src/Beckett.Dashboard/MessageStore/Message/MessageByStreamPositionEndpoint.cs
@@ -15,7 +15,7 @@ public static class MessageByStreamPositionEndpoint
         var decodedStreamName = HttpUtility.UrlDecode(streamName);
 
         var result = await database.Execute(
-            new MessageByStreamPositionQuery(decodedStreamName, streamPosition, options),
+            new MessageByStreamPositionQuery(decodedStreamName, streamPosition),
             cancellationToken
         );
 

--- a/src/Beckett.Dashboard/MessageStore/Message/MessageByStreamPositionQuery.cs
+++ b/src/Beckett.Dashboard/MessageStore/Message/MessageByStreamPositionQuery.cs
@@ -11,6 +11,7 @@ public class MessageByStreamPositionQuery(string streamName, long streamPosition
 {
     public async Task<MessageResult?> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             SELECT id::text,
                    beckett.stream_category(m.stream_name) AS category,

--- a/src/Beckett.Dashboard/MessageStore/Message/MessageQuery.cs
+++ b/src/Beckett.Dashboard/MessageStore/Message/MessageQuery.cs
@@ -10,6 +10,7 @@ public class MessageQuery(Guid id) : IPostgresDatabaseQuery<MessageResult?>
 {
     public async Task<MessageResult?> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             SELECT beckett.stream_category(m.stream_name) AS category,
                    m.stream_name,

--- a/src/Beckett.Dashboard/MessageStore/Messages/MessagesEndpoint.cs
+++ b/src/Beckett.Dashboard/MessageStore/Messages/MessagesEndpoint.cs
@@ -21,7 +21,7 @@ public static class MessagesEndpoint
         var offset = Pagination.ToOffset(pageParameter, pageSizeParameter);
 
         var result = await database.Execute(
-            new MessagesQuery(streamName, query, offset, pageSizeParameter, options),
+            new MessagesQuery(streamName, query, offset, pageSizeParameter),
             cancellationToken
         );
 

--- a/src/Beckett.Dashboard/MessageStore/Messages/MessagesQuery.cs
+++ b/src/Beckett.Dashboard/MessageStore/Messages/MessagesQuery.cs
@@ -13,6 +13,7 @@ public class MessagesQuery(
 {
     public async Task<Result> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             SELECT id, stream_position, type, timestamp, count(*) over() AS total_results
             FROM beckett.messages

--- a/src/Beckett.Dashboard/MessageStore/Messages/MessagesQuery.cs
+++ b/src/Beckett.Dashboard/MessageStore/Messages/MessagesQuery.cs
@@ -8,29 +8,30 @@ public class MessagesQuery(
     string streamName,
     string? query,
     int offset,
-    int limit,
-    PostgresOptions options
+    int limit
 ) : IPostgresDatabaseQuery<MessagesQuery.Result>
 {
     public async Task<Result> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
-        command.CommandText = $@"
+        const string sql = """
             SELECT id, stream_position, type, timestamp, count(*) over() AS total_results
-            FROM {options.Schema}.messages
+            FROM beckett.messages
             WHERE stream_name = $1
             AND ($2 IS NULL OR (id::text ILIKE '%' || $2 || '%' OR type ILIKE '%' || $2 || '%'))
             AND archived = false
             ORDER BY stream_position
             OFFSET $3
             LIMIT $4;
-        ";
+        """;
+
+        command.CommandText = Query.Build(nameof(MessagesQuery), sql, out var prepare);
 
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text, IsNullable = true });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Integer });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Integer });
 
-        if (options.PrepareStatements)
+        if (prepare)
         {
             await command.PrepareAsync(cancellationToken);
         }

--- a/src/Beckett.Dashboard/MessageStore/Streams/StreamsEndpoint.cs
+++ b/src/Beckett.Dashboard/MessageStore/Streams/StreamsEndpoint.cs
@@ -23,7 +23,7 @@ public static class StreamsEndpoint
         var offset = Pagination.ToOffset(pageParameter, pageSizeParameter);
 
         var result = await database.Execute(
-            new StreamsQuery(tenant, decodedCategory, query, offset, pageSizeParameter, options),
+            new StreamsQuery(tenant, decodedCategory, query, offset, pageSizeParameter),
             cancellationToken
         );
 

--- a/src/Beckett.Dashboard/MessageStore/Streams/StreamsQuery.cs
+++ b/src/Beckett.Dashboard/MessageStore/Streams/StreamsQuery.cs
@@ -14,6 +14,7 @@ public class StreamsQuery(
 {
     public async Task<Result> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
            SELECT stream_name,
                   max(timestamp) AS last_updated,

--- a/src/Beckett.Dashboard/MessageStore/Streams/StreamsQuery.cs
+++ b/src/Beckett.Dashboard/MessageStore/Streams/StreamsQuery.cs
@@ -9,19 +9,18 @@ public class StreamsQuery(
     string category,
     string? query,
     int offset,
-    int limit,
-    PostgresOptions options
+    int limit
 ) : IPostgresDatabaseQuery<StreamsQuery.Result>
 {
     public async Task<Result> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
-        command.CommandText = $"""
+        const string sql = """
            SELECT stream_name,
                   max(timestamp) AS last_updated,
                   count(*) over() AS total_results
-           FROM {options.Schema}.messages_active
+           FROM beckett.messages_active
            WHERE metadata ->> '$tenant' = $1
-           AND {options.Schema}.stream_category(stream_name) = $2
+           AND beckett.stream_category(stream_name) = $2
            AND ($3 IS NULL OR stream_name ILIKE '%' || $3 || '%')
            GROUP BY stream_name
            ORDER BY max(timestamp) DESC
@@ -29,13 +28,15 @@ public class StreamsQuery(
            LIMIT $5;
         """;
 
+        command.CommandText = Query.Build(nameof(StreamsQuery), sql, out var prepare);
+
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text, IsNullable = true });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Integer });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Integer });
 
-        if (options.PrepareStatements)
+        if (prepare)
         {
             await command.PrepareAsync(cancellationToken);
         }

--- a/src/Beckett.Dashboard/Metrics/Metrics.razor
+++ b/src/Beckett.Dashboard/Metrics/Metrics.razor
@@ -1,7 +1,6 @@
 @using Beckett.Database
 @inherits Component<Metrics.ViewModel>
 @inject IPostgresDatabase Database
-@inject PostgresOptions PostgresOptions
 
 <a href="@Dashboard.Prefix/subscriptions/checkpoints/lagging"
    class="badge text-bg-info text-decoration-none"
@@ -30,7 +29,7 @@
       return;
     }
 
-    var result = await Database.Execute(new MetricsQuery(PostgresOptions), CancellationToken.None);
+    var result = await Database.Execute(new MetricsQuery(), CancellationToken.None);
 
     Model = new ViewModel(result.Lagging, result.Retries, result.Failed, false);
   }

--- a/src/Beckett.Dashboard/Metrics/MetricsEndpoint.cs
+++ b/src/Beckett.Dashboard/Metrics/MetricsEndpoint.cs
@@ -10,7 +10,7 @@ public static class MetricsEndpoint
         CancellationToken cancellationToken
     )
     {
-        var result = await database.Execute(new MetricsQuery(options), cancellationToken);
+        var result = await database.Execute(new MetricsQuery(), cancellationToken);
 
         return Results.Extensions.Render<Metrics>(
             new Metrics.ViewModel(result.Lagging, result.Retries, result.Failed, false)

--- a/src/Beckett.Dashboard/Metrics/MetricsQuery.cs
+++ b/src/Beckett.Dashboard/Metrics/MetricsQuery.cs
@@ -3,11 +3,11 @@ using Npgsql;
 
 namespace Beckett.Dashboard.Metrics;
 
-public class MetricsQuery(PostgresOptions options) : IPostgresDatabaseQuery<MetricsQuery.Result>
+public class MetricsQuery : IPostgresDatabaseQuery<MetricsQuery.Result>
 {
     public async Task<Result> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
-        command.CommandText = $@"
+        const string sql = """
             SELECT l.lagging, r.retries, f.failed
             FROM (
                 WITH lagging_subscriptions AS (
@@ -36,9 +36,11 @@ public class MetricsQuery(PostgresOptions options) : IPostgresDatabaseQuery<Metr
                 WHERE s.status != 'uninitialized'
                 AND c.status = 'failed'
             ) AS f;
-        ";
+        """;
 
-        if (options.PrepareStatements)
+        command.CommandText = Query.Build(nameof(MetricsQuery), sql, out var prepare);
+
+        if (prepare)
         {
             await command.PrepareAsync(cancellationToken);
         }

--- a/src/Beckett.Dashboard/Metrics/MetricsQuery.cs
+++ b/src/Beckett.Dashboard/Metrics/MetricsQuery.cs
@@ -7,6 +7,7 @@ public class MetricsQuery : IPostgresDatabaseQuery<MetricsQuery.Result>
 {
     public async Task<Result> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             SELECT l.lagging, r.retries, f.failed
             FROM (

--- a/src/Beckett.Dashboard/Scheduled/Message/MessageEndpoint.cs
+++ b/src/Beckett.Dashboard/Scheduled/Message/MessageEndpoint.cs
@@ -12,7 +12,7 @@ public static class MessageEndpoint
         CancellationToken cancellationToken
     )
     {
-        var viewModel = await database.Execute(new MessageQuery(id, options), cancellationToken);
+        var viewModel = await database.Execute(new MessageQuery(id), cancellationToken);
 
         if (viewModel is not null)
         {

--- a/src/Beckett.Dashboard/Scheduled/Message/MessageQuery.cs
+++ b/src/Beckett.Dashboard/Scheduled/Message/MessageQuery.cs
@@ -10,6 +10,7 @@ public class MessageQuery(Guid id) : IPostgresDatabaseQuery<Message.ViewModel?>
 {
     public async Task<Message.ViewModel?> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             SELECT stream_name,
                    type,

--- a/src/Beckett.Dashboard/Scheduled/Messages/MessagesEndpoint.cs
+++ b/src/Beckett.Dashboard/Scheduled/Messages/MessagesEndpoint.cs
@@ -18,7 +18,7 @@ public static class MessagesEndpoint
         var offset = Pagination.ToOffset(pageParameter, pageSizeParameter);
 
         var result = await database.Execute(
-            new Query(query, offset, pageSizeParameter, options),
+            new MessagesQuery(query, offset, pageSizeParameter),
             cancellationToken
         );
 

--- a/src/Beckett.Dashboard/Scheduled/Messages/MessagesQuery.cs
+++ b/src/Beckett.Dashboard/Scheduled/Messages/MessagesQuery.cs
@@ -4,29 +4,30 @@ using NpgsqlTypes;
 
 namespace Beckett.Dashboard.Scheduled.Messages;
 
-public class Query(
+public class MessagesQuery(
     string? query,
     int offset,
-    int limit,
-    PostgresOptions options
-) : IPostgresDatabaseQuery<Query.Result>
+    int limit
+) : IPostgresDatabaseQuery<MessagesQuery.Result>
 {
     public async Task<Result> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
-        command.CommandText = $@"
+        const string sql = """
             SELECT id, stream_name, type, deliver_at, count(*) over() AS total_results
-            FROM {options.Schema}.scheduled_messages
+            FROM beckett.scheduled_messages
             WHERE ($1 IS NULL OR (stream_name ILIKE '%' || $1 || '%' OR type ILIKE '%' || $1 || '%'))
             ORDER BY deliver_at
             OFFSET $2
             LIMIT $3;
-        ";
+        """;
+
+        command.CommandText = Query.Build(nameof(Query), sql, out var prepare);
 
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text, IsNullable = true });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Integer });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Integer });
 
-        if (options.PrepareStatements)
+        if (prepare)
         {
             await command.PrepareAsync(cancellationToken);
         }

--- a/src/Beckett.Dashboard/Scheduled/Messages/MessagesQuery.cs
+++ b/src/Beckett.Dashboard/Scheduled/Messages/MessagesQuery.cs
@@ -12,6 +12,7 @@ public class MessagesQuery(
 {
     public async Task<Result> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             SELECT id, stream_name, type, deliver_at, count(*) over() AS total_results
             FROM beckett.scheduled_messages

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/BulkRetry/BulkRetryEndpoint.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/BulkRetry/BulkRetryEndpoint.cs
@@ -13,7 +13,7 @@ public static class BulkRetryEndpoint
         CancellationToken cancellationToken
     )
     {
-        await database.Execute(new ScheduleCheckpoints(ids, DateTimeOffset.UtcNow, options), cancellationToken);
+        await database.Execute(new ScheduleCheckpoints(ids, DateTimeOffset.UtcNow), cancellationToken);
 
         context.Response.Headers.Append("HX-Refresh", new StringValues("true"));
         context.Response.Headers.Append("HX-Trigger", new StringValues("bulk_retry_requested"));

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/BulkSkip/BulkSkipEndpoint.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/BulkSkip/BulkSkipEndpoint.cs
@@ -12,7 +12,7 @@ public static class BulkSkipEndpoint
         CancellationToken cancellationToken
     )
     {
-        await database.Execute(new BulkSkipQuery(ids, options), cancellationToken);
+        await database.Execute(new BulkSkipQuery(ids), cancellationToken);
 
         context.Response.Headers.Append("HX-Refresh", new StringValues("true"));
         context.Response.Headers.Append("HX-Trigger", new StringValues("bulk_skip_requested"));

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/BulkSkip/BulkSkipQuery.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/BulkSkip/BulkSkipQuery.cs
@@ -10,6 +10,7 @@ public class BulkSkipQuery(
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             UPDATE beckett.checkpoints
             SET stream_position = CASE WHEN stream_position + 1 > stream_version THEN stream_position ELSE stream_position + 1 END,

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/BulkSkip/BulkSkipQuery.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/BulkSkip/BulkSkipQuery.cs
@@ -5,25 +5,26 @@ using NpgsqlTypes;
 namespace Beckett.Dashboard.Subscriptions.Checkpoints.BulkSkip;
 
 public class BulkSkipQuery(
-    long[] ids,
-    PostgresOptions options
+    long[] ids
 ) : IPostgresDatabaseQuery<int>
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
-        command.CommandText = $@"
-            UPDATE {options.Schema}.checkpoints
+        const string sql = """
+            UPDATE beckett.checkpoints
             SET stream_position = CASE WHEN stream_position + 1 > stream_version THEN stream_position ELSE stream_position + 1 END,
                 process_at = NULL,
                 reserved_until = NULL,
                 status = 'active',
                 retries = NULL
             WHERE id = ANY($1);
-        ";
+        """;
+
+        command.CommandText = Query.Build(nameof(BulkSkipQuery), sql, out var prepare);
 
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Array | NpgsqlDbType.Bigint });
 
-        if (options.PrepareStatements)
+        if (prepare)
         {
             await command.PrepareAsync(cancellationToken);
         }

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/Checkpoint/CheckpointEndpoint.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/Checkpoint/CheckpointEndpoint.cs
@@ -11,7 +11,7 @@ public static class CheckpointEndpoint
         CancellationToken cancellationToken
     )
     {
-        var result = await database.Execute(new CheckpointQuery(id, options), cancellationToken);
+        var result = await database.Execute(new CheckpointQuery(id), cancellationToken);
 
         return result == null
             ? Results.NotFound()

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/Checkpoint/CheckpointQuery.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/Checkpoint/CheckpointQuery.cs
@@ -6,11 +6,11 @@ using NpgsqlTypes;
 
 namespace Beckett.Dashboard.Subscriptions.Checkpoints.Checkpoint;
 
-public class CheckpointQuery(long id, PostgresOptions options) : IPostgresDatabaseQuery<CheckpointQuery.Result?>
+public class CheckpointQuery(long id) : IPostgresDatabaseQuery<CheckpointQuery.Result?>
 {
     public async Task<Result?> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
-        command.CommandText = $@"
+        const string sql = """
             SELECT c.id,
                    c.group_name,
                    c.name,
@@ -23,14 +23,16 @@ public class CheckpointQuery(long id, PostgresOptions options) : IPostgresDataba
                    c.retries,
                    m.stream_name as actual_stream_name,
                    m.stream_position as actual_stream_position
-            FROM {options.Schema}.checkpoints c
-            LEFT JOIN {options.Schema}.messages m on c.stream_name = '$global' and c.stream_position = m.global_position
+            FROM beckett.checkpoints c
+            LEFT JOIN beckett.messages m on c.stream_name = '$global' and c.stream_position = m.global_position
             WHERE c.id = $1;
-        ";
+        """;
+
+        command.CommandText = Query.Build(nameof(CheckpointQuery), sql, out var prepare);
 
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Bigint });
 
-        if (options.PrepareStatements)
+        if (prepare)
         {
             await command.PrepareAsync(cancellationToken);
         }

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/Checkpoint/CheckpointQuery.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/Checkpoint/CheckpointQuery.cs
@@ -10,6 +10,7 @@ public class CheckpointQuery(long id) : IPostgresDatabaseQuery<CheckpointQuery.R
 {
     public async Task<Result?> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             SELECT c.id,
                    c.group_name,

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/Failed/FailedEndpoint.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/Failed/FailedEndpoint.cs
@@ -18,7 +18,7 @@ public static class FailedEndpoint
         var offset = Pagination.ToOffset(pageParameter, pageSizeParameter);
 
         var result = await database.Execute(
-            new FailedQuery(query, offset, pageSizeParameter, options),
+            new FailedQuery(query, offset, pageSizeParameter),
             cancellationToken
         );
 

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/Failed/FailedQuery.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/Failed/FailedQuery.cs
@@ -12,6 +12,7 @@ public class FailedQuery(
 {
     public async Task<Result> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             SELECT id, group_name, name, stream_name, stream_position, updated_at, count(*) over() as total_results
             FROM beckett.checkpoints

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/Lagging/LaggingEndpoint.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/Lagging/LaggingEndpoint.cs
@@ -17,7 +17,7 @@ public static class LaggingEndpoint
         var offset = Pagination.ToOffset(pageParameter, pageSizeParameter);
 
         var result = await database.Execute(
-            new LaggingQuery(offset, pageSizeParameter, options),
+            new LaggingQuery(offset, pageSizeParameter),
             cancellationToken
         );
 

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/Lagging/LaggingQuery.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/Lagging/LaggingQuery.cs
@@ -6,19 +6,18 @@ namespace Beckett.Dashboard.Subscriptions.Checkpoints.Lagging;
 
 public class LaggingQuery(
     int offset,
-    int limit,
-    PostgresOptions options
+    int limit
 ) : IPostgresDatabaseQuery<LaggingQuery.Result>
 {
     public async Task<Result> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
-        command.CommandText = $@"
+        const string sql = """
             SELECT c.group_name,
                    c.name,
                    sum(greatest(0, c.stream_version - c.stream_position)) AS total_lag,
                    count(*) over() as total_results
-            FROM {options.Schema}.subscriptions s
-            INNER JOIN {options.Schema}.checkpoints c ON s.group_name = c.group_name AND s.name = c.name
+            FROM beckett.subscriptions s
+            INNER JOIN beckett.checkpoints c ON s.group_name = c.group_name AND s.name = c.name
             WHERE s.status in ('active', 'replay')
             AND c.status = 'active'
             AND c.lagging = true
@@ -26,12 +25,14 @@ public class LaggingQuery(
             ORDER BY c.group_name, sum(greatest(0, c.stream_version - c.stream_position)) DESC, name
             OFFSET $1
             LIMIT $2;
-        ";
+        """;
+
+        command.CommandText = Query.Build(nameof(LaggingQuery), sql, out var prepare);
 
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Integer });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Integer });
 
-        if (options.PrepareStatements)
+        if (prepare)
         {
             await command.PrepareAsync(cancellationToken);
         }

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/Lagging/LaggingQuery.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/Lagging/LaggingQuery.cs
@@ -11,6 +11,7 @@ public class LaggingQuery(
 {
     public async Task<Result> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             SELECT c.group_name,
                    c.name,

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/ReleaseReservation/ReleaseReservationEndpoint.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/ReleaseReservation/ReleaseReservationEndpoint.cs
@@ -13,7 +13,7 @@ public static class ReleaseReservationEndpoint
         CancellationToken cancellationToken
     )
     {
-        await database.Execute(new ReleaseCheckpointReservation(id, options), cancellationToken);
+        await database.Execute(new ReleaseCheckpointReservation(id), cancellationToken);
 
         context.Response.Headers.Append("HX-Refresh", new StringValues("true"));
         context.Response.Headers.Append("HX-Trigger", new StringValues("reservation_released"));

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/Reservations/ReservationsEndpoint.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/Reservations/ReservationsEndpoint.cs
@@ -18,7 +18,7 @@ public static class ReservationsEndpoint
         var offset = Pagination.ToOffset(pageParameter, pageSizeParameter);
 
         var result = await database.Execute(
-            new ReservationsQuery(query, offset, pageSizeParameter, options),
+            new ReservationsQuery(query, offset, pageSizeParameter),
             cancellationToken
         );
 

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/Reservations/ReservationsQuery.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/Reservations/ReservationsQuery.cs
@@ -7,27 +7,28 @@ namespace Beckett.Dashboard.Subscriptions.Checkpoints.Reservations;
 public class ReservationsQuery(
     string? query,
     int offset,
-    int limit,
-    PostgresOptions options
+    int limit
 ) : IPostgresDatabaseQuery<ReservationsQuery.Result>
 {
     public async Task<Result> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
-        command.CommandText = $@"
+        const string sql = """
             SELECT id, group_name, name, stream_name, stream_position, reserved_until, count(*) over() as total_results
-            FROM {options.Schema}.checkpoints
+            FROM beckett.checkpoints
             WHERE reserved_until IS NOT NULL
             AND ($1 is null or (group_name ILIKE '%' || $1 || '%' OR name ILIKE '%' || $1 || '%' OR stream_name ILIKE '%' || $1 || '%'))
             ORDER BY reserved_until
             OFFSET $2
             LIMIT $3;
-        ";
+        """;
+
+        command.CommandText = Query.Build(nameof(ReservationsQuery), sql, out var prepare);
 
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text, IsNullable = true });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Integer });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Integer });
 
-        if (options.PrepareStatements)
+        if (prepare)
         {
             await command.PrepareAsync(cancellationToken);
         }

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/Reservations/ReservationsQuery.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/Reservations/ReservationsQuery.cs
@@ -12,6 +12,7 @@ public class ReservationsQuery(
 {
     public async Task<Result> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             SELECT id, group_name, name, stream_name, stream_position, reserved_until, count(*) over() as total_results
             FROM beckett.checkpoints

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/Retries/RetriesEndpoint.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/Retries/RetriesEndpoint.cs
@@ -18,7 +18,7 @@ public static class RetriesEndpoint
         var offset = Pagination.ToOffset(pageParameter, pageSizeParameter);
 
         var result = await database.Execute(
-            new RetriesQuery(query, offset, pageSizeParameter, options),
+            new RetriesQuery(query, offset, pageSizeParameter),
             cancellationToken
         );
 

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/Retries/RetriesQuery.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/Retries/RetriesQuery.cs
@@ -12,6 +12,7 @@ public class RetriesQuery(
 {
     public async Task<Result> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             SELECT id, group_name, name, stream_name, stream_position, updated_at, count(*) over() as total_results
             FROM beckett.checkpoints

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/Retries/RetriesQuery.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/Retries/RetriesQuery.cs
@@ -7,27 +7,28 @@ namespace Beckett.Dashboard.Subscriptions.Checkpoints.Retries;
 public class RetriesQuery(
     string? query,
     int offset,
-    int limit,
-    PostgresOptions options
+    int limit
 ) : IPostgresDatabaseQuery<RetriesQuery.Result>
 {
     public async Task<Result> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
-        command.CommandText = $@"
+        const string sql = """
             SELECT id, group_name, name, stream_name, stream_position, updated_at, count(*) over() as total_results
-            FROM {options.Schema}.checkpoints
+            FROM beckett.checkpoints
             WHERE status = 'retry'
             AND ($1 is null or (group_name ILIKE '%' || $1 || '%' OR name ILIKE '%' || $1 || '%' OR stream_name ILIKE '%' || $1 || '%'))
             ORDER BY updated_at desc, group_name, name, stream_name, stream_position
             OFFSET $2
             LIMIT $3;
-        ";
+        """;
+
+        command.CommandText = Query.Build(nameof(RetriesQuery), sql, out var prepare);
 
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text, IsNullable = true });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Integer });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Integer });
 
-        if (options.PrepareStatements)
+        if (prepare)
         {
             await command.PrepareAsync(cancellationToken);
         }

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/Retry/RetryEndpoint.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/Retry/RetryEndpoint.cs
@@ -13,7 +13,7 @@ public static class RetryEndpoint
         CancellationToken cancellationToken
     )
     {
-        await database.Execute(new ScheduleCheckpoints([id], DateTimeOffset.UtcNow, options), cancellationToken);
+        await database.Execute(new ScheduleCheckpoints([id], DateTimeOffset.UtcNow), cancellationToken);
 
         context.Response.Headers.Append("HX-Refresh", new StringValues("true"));
         context.Response.Headers.Append("HX-Trigger", new StringValues("retry_requested"));

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/Shared/Queries/ScheduleCheckpoints.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/Shared/Queries/ScheduleCheckpoints.cs
@@ -11,6 +11,7 @@ public class ScheduleCheckpoints(
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             UPDATE beckett.checkpoints
             SET process_at = $2

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/Shared/Queries/ScheduleCheckpoints.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/Shared/Queries/ScheduleCheckpoints.cs
@@ -6,22 +6,23 @@ namespace Beckett.Dashboard.Subscriptions.Checkpoints.Shared.Queries;
 
 public class ScheduleCheckpoints(
     long[] ids,
-    DateTimeOffset processAt,
-    PostgresOptions options
+    DateTimeOffset processAt
 ) : IPostgresDatabaseQuery<int>
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
-        command.CommandText = $"""
-            UPDATE {options.Schema}.checkpoints
+        const string sql = """
+            UPDATE beckett.checkpoints
             SET process_at = $2
             WHERE id = ANY($1);
         """;
 
+        command.CommandText = Query.Build(nameof(ScheduleCheckpoints), sql, out var prepare);
+
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Array | NpgsqlDbType.Bigint });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.TimestampTz });
 
-        if (options.PrepareStatements)
+        if (prepare)
         {
             await command.PrepareAsync(cancellationToken);
         }

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/Skip/SkipEndpoint.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/Skip/SkipEndpoint.cs
@@ -12,7 +12,7 @@ public static class SkipEndpoint
         CancellationToken cancellationToken
     )
     {
-        await database.Execute(new SkipQuery(id, options), cancellationToken);
+        await database.Execute(new SkipQuery(id), cancellationToken);
 
         context.Response.Headers.Append("HX-Refresh", new StringValues("true"));
         context.Response.Headers.Append("HX-Trigger", new StringValues("checkpoint_skipped"));

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/Skip/SkipQuery.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/Skip/SkipQuery.cs
@@ -10,6 +10,7 @@ public class SkipQuery(
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             UPDATE beckett.checkpoints
             SET stream_position = CASE WHEN stream_position + 1 > stream_version THEN stream_position ELSE stream_position + 1 END,

--- a/src/Beckett.Dashboard/Subscriptions/Groups/GroupsEndpoint.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Groups/GroupsEndpoint.cs
@@ -18,7 +18,7 @@ public static class GroupsEndpoint
         var offset = Pagination.ToOffset(pageParameter, pageSizeParameter);
 
         var result = await database.Execute(
-            new GroupsQuery(query, offset, pageSizeParameter, options),
+            new GroupsQuery(query, offset, pageSizeParameter),
             cancellationToken
         );
 

--- a/src/Beckett.Dashboard/Subscriptions/Groups/GroupsQuery.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Groups/GroupsQuery.cs
@@ -12,6 +12,7 @@ public class GroupsQuery(
 {
     public async Task<Result> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             SELECT group_name, count(*) over() as total_results
             FROM beckett.subscriptions

--- a/src/Beckett.Dashboard/Subscriptions/Groups/GroupsQuery.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Groups/GroupsQuery.cs
@@ -7,27 +7,28 @@ namespace Beckett.Dashboard.Subscriptions.Groups;
 public class GroupsQuery(
     string? query,
     int offset,
-    int limit,
-    PostgresOptions options
+    int limit
 ) : IPostgresDatabaseQuery<GroupsQuery.Result>
 {
     public async Task<Result> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
-        command.CommandText = $@"
+        const string sql = """
             SELECT group_name, count(*) over() as total_results
-            FROM {options.Schema}.subscriptions
+            FROM beckett.subscriptions
             WHERE ($1 IS NULL or name ILIKE '%' || $1 || '%')
             GROUP BY group_name
             ORDER BY group_name
             OFFSET $2
             LIMIT $3;
-        ";
+        """;
+
+        command.CommandText = Query.Build(nameof(GroupsQuery), sql, out var prepare);
 
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text, IsNullable = true });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Integer });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Integer });
 
-        if (options.PrepareStatements)
+        if (prepare)
         {
             await command.PrepareAsync(cancellationToken);
         }

--- a/src/Beckett.Dashboard/Subscriptions/Pause/PauseEndpoint.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Pause/PauseEndpoint.cs
@@ -13,7 +13,7 @@ public static class PauseEndpoint
         CancellationToken cancellationToken
     )
     {
-        await database.Execute(new PauseQuery(groupName, name, options), cancellationToken);
+        await database.Execute(new PauseQuery(groupName, name), cancellationToken);
 
         context.Response.Headers.Append("HX-Refresh", new StringValues("true"));
 

--- a/src/Beckett.Dashboard/Subscriptions/Pause/PauseQuery.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Pause/PauseQuery.cs
@@ -11,6 +11,7 @@ public class PauseQuery(
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             UPDATE beckett.subscriptions
             SET status = 'paused'

--- a/src/Beckett.Dashboard/Subscriptions/Pause/PauseQuery.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Pause/PauseQuery.cs
@@ -6,23 +6,24 @@ namespace Beckett.Dashboard.Subscriptions.Pause;
 
 public class PauseQuery(
     string groupName,
-    string name,
-    PostgresOptions options
+    string name
 ) : IPostgresDatabaseQuery<int>
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
-        command.CommandText = $"""
-            UPDATE {options.Schema}.subscriptions
+        const string sql = """
+            UPDATE beckett.subscriptions
             SET status = 'paused'
             WHERE group_name = $1
             AND name = $2;
         """;
 
+        command.CommandText = Query.Build(nameof(PauseQuery), sql, out var prepare);
+
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
 
-        if (options.PrepareStatements)
+        if (prepare)
         {
             await command.PrepareAsync(cancellationToken);
         }

--- a/src/Beckett.Dashboard/Subscriptions/Replay/ReplayEndpoint.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Replay/ReplayEndpoint.cs
@@ -13,7 +13,7 @@ public static class ReplayEndpoint
         CancellationToken cancellationToken
     )
     {
-        await database.Execute(new ReplayQuery(groupName, name, options), cancellationToken);
+        await database.Execute(new ReplayQuery(groupName, name), cancellationToken);
 
         context.Response.Headers.Append("HX-Refresh", new StringValues("true"));
         context.Response.Headers.Append("HX-Trigger", new StringValues("subscription_replay_started"));

--- a/src/Beckett.Dashboard/Subscriptions/Replay/ReplayQuery.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Replay/ReplayQuery.cs
@@ -6,18 +6,19 @@ namespace Beckett.Dashboard.Subscriptions.Replay;
 
 public class ReplayQuery(
     string groupName,
-    string name,
-    PostgresOptions options
+    string name
 ) : IPostgresDatabaseQuery<int>
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
-        command.CommandText = @$"SELECT {options.Schema}.replay_subscription($1, $2);";
+        const string sql = "SELECT beckett.replay_subscription($1, $2);";
+
+        command.CommandText = Query.Build(nameof(ReplayQuery), sql, out var prepare);
 
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
 
-        if (options.PrepareStatements)
+        if (prepare)
         {
             await command.PrepareAsync(cancellationToken);
         }

--- a/src/Beckett.Dashboard/Subscriptions/Replay/ReplayQuery.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Replay/ReplayQuery.cs
@@ -11,6 +11,7 @@ public class ReplayQuery(
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = "SELECT beckett.replay_subscription($1, $2);";
 
         command.CommandText = Query.Build(nameof(ReplayQuery), sql, out var prepare);

--- a/src/Beckett.Dashboard/Subscriptions/Resume/ResumeEndpoint.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Resume/ResumeEndpoint.cs
@@ -13,7 +13,7 @@ public static class ResumeEndpoint
         CancellationToken cancellationToken
     )
     {
-        await database.Execute(new ResumeQuery(groupName, name, options), cancellationToken);
+        await database.Execute(new ResumeQuery(groupName, name), cancellationToken);
 
         context.Response.Headers.Append("HX-Refresh", new StringValues("true"));
 

--- a/src/Beckett.Dashboard/Subscriptions/Resume/ResumeQuery.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Resume/ResumeQuery.cs
@@ -11,6 +11,7 @@ public class ResumeQuery(
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             WITH notify AS (
                 SELECT pg_notify('beckett:checkpoints', $1)

--- a/src/Beckett.Dashboard/Subscriptions/Subscription/SubscriptionEndpoint.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Subscription/SubscriptionEndpoint.cs
@@ -12,7 +12,7 @@ public static class SubscriptionEndpoint
         CancellationToken cancellationToken
     )
     {
-        var result = await database.Execute(new SubscriptionQuery(groupName, name, options), cancellationToken);
+        var result = await database.Execute(new SubscriptionQuery(groupName, name), cancellationToken);
 
         return result == null
             ? Results.NotFound()

--- a/src/Beckett.Dashboard/Subscriptions/Subscription/SubscriptionQuery.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Subscription/SubscriptionQuery.cs
@@ -11,6 +11,7 @@ public class SubscriptionQuery(
 {
     public async Task<Result?> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             SELECT group_name, name, status
             FROM beckett.subscriptions

--- a/src/Beckett.Dashboard/Subscriptions/Subscription/SubscriptionQuery.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Subscription/SubscriptionQuery.cs
@@ -7,22 +7,23 @@ namespace Beckett.Dashboard.Subscriptions.Subscription;
 
 public class SubscriptionQuery(
     string groupName,
-    string name,
-    PostgresOptions options) : IPostgresDatabaseQuery<SubscriptionQuery.Result?>
+    string name) : IPostgresDatabaseQuery<SubscriptionQuery.Result?>
 {
     public async Task<Result?> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
-        command.CommandText = $@"
+        const string sql = """
             SELECT group_name, name, status
-            FROM {options.Schema}.subscriptions
+            FROM beckett.subscriptions
             WHERE group_name = $1
             AND name = $2;
-        ";
+        """;
+
+        command.CommandText = Query.Build(nameof(SubscriptionQuery), sql, out var prepare);
 
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
 
-        if (options.PrepareStatements)
+        if (prepare)
         {
             await command.PrepareAsync(cancellationToken);
         }

--- a/src/Beckett.Dashboard/Subscriptions/Subscriptions/SubscriptionsEndpoint.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Subscriptions/SubscriptionsEndpoint.cs
@@ -19,7 +19,7 @@ public static class SubscriptionsEndpoint
         var offset = Pagination.ToOffset(pageParameter, pageSizeParameter);
 
         var result = await database.Execute(
-            new SubscriptionsQuery(groupName, query, offset, pageSizeParameter, options),
+            new SubscriptionsQuery(groupName, query, offset, pageSizeParameter),
             cancellationToken
         );
 

--- a/src/Beckett.Dashboard/Subscriptions/Subscriptions/SubscriptionsQuery.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Subscriptions/SubscriptionsQuery.cs
@@ -14,6 +14,7 @@ public class SubscriptionsQuery(
 {
     public async Task<Result> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             SELECT name, status, count(*) over() as total_results
             FROM beckett.subscriptions

--- a/src/Beckett.Tests/Subscriptions/CheckpointProcessorTests.cs
+++ b/src/Beckett.Tests/Subscriptions/CheckpointProcessorTests.cs
@@ -32,7 +32,7 @@ public class CheckpointProcessorTests
                 subscription.RegisterMessageType<TestMessage>();
                 subscription.BuildHandler();
                 var messageStorage = Substitute.For<IMessageStorage>();
-                var checkpointProcessor = BuildCheckpointProcessor(options, messageStorage);
+                var checkpointProcessor = BuildCheckpointProcessor(messageStorage);
 
                 await checkpointProcessor.Process(1, checkpoint, subscription);
 
@@ -62,7 +62,7 @@ public class CheckpointProcessorTests
                 subscription.RegisterMessageType<TestMessage>();
                 subscription.BuildHandler();
                 var messageStorage = Substitute.For<IMessageStorage>();
-                var checkpointProcessor = BuildCheckpointProcessor(options, messageStorage);
+                var checkpointProcessor = BuildCheckpointProcessor(messageStorage);
 
                 await checkpointProcessor.Process(1, checkpoint, subscription);
 
@@ -97,7 +97,7 @@ public class CheckpointProcessorTests
             subscription.BuildHandler();
             var messageStorage = Substitute.For<IMessageStorage>();
             var database = Substitute.For<IPostgresDatabase>();
-            var checkpointProcessor = BuildCheckpointProcessor(options, messageStorage, database);
+            var checkpointProcessor = BuildCheckpointProcessor(messageStorage, database);
             messageStorage.ReadStream("test", Arg.Any<ReadStreamOptions>(), CancellationToken.None)
                 .Returns(new ReadStreamResult("test", 2, [BuildStreamMessage()]));
             RecordCheckpointError? error = null;
@@ -133,7 +133,7 @@ public class CheckpointProcessorTests
             subscription.BuildHandler();
             var messageStorage = Substitute.For<IMessageStorage>();
             var database = Substitute.For<IPostgresDatabase>();
-            var checkpointProcessor = BuildCheckpointProcessor(options, messageStorage, database);
+            var checkpointProcessor = BuildCheckpointProcessor(messageStorage, database);
             messageStorage.ReadStream("test", Arg.Any<ReadStreamOptions>(), CancellationToken.None)
                 .Returns(new ReadStreamResult("test", 2, [BuildStreamMessage()]));
             RecordCheckpointError? error = null;
@@ -165,7 +165,7 @@ public class CheckpointProcessorTests
             subscription.RegisterMessageType<TestMessage>();
             subscription.BuildHandler();
             var messageStorage = Substitute.For<IMessageStorage>();
-            var checkpointProcessor = BuildCheckpointProcessor(options, messageStorage);
+            var checkpointProcessor = BuildCheckpointProcessor(messageStorage);
 
             await checkpointProcessor.Process(1, checkpoint, subscription);
 
@@ -199,7 +199,6 @@ public class CheckpointProcessorTests
     }
 
     private static CheckpointProcessor BuildCheckpointProcessor(
-        BeckettOptions options,
         IMessageStorage messageStorage,
         IPostgresDatabase? database = null
     )
@@ -215,7 +214,6 @@ public class CheckpointProcessorTests
             dataSource,
             database,
             serviceProvider,
-            options,
             instrumentation,
             logger
         );

--- a/src/Beckett/Database/Query.cs
+++ b/src/Beckett/Database/Query.cs
@@ -1,0 +1,31 @@
+using System.Collections.Concurrent;
+
+namespace Beckett.Database;
+
+public static class Query
+{
+    private static readonly ConcurrentDictionary<string, string> _registry = [];
+    private static PostgresOptions? _options;
+
+    public static void Initialize(PostgresOptions options)
+    {
+        _options = options;
+    }
+
+    public static string Build(string key, string sql, out bool prepare)
+    {
+        if (_options == null)
+        {
+            throw new InvalidOperationException("QueryRegistry must be initialized prior to usage");
+        }
+
+        prepare = _options.PrepareStatements;
+
+        return _registry.GetOrAdd(
+            key,
+            _ => _options.Schema == PostgresOptions.DefaultSchema
+                ? sql
+                : sql.Replace(PostgresOptions.DefaultSchema, _options.Schema)
+        );
+    }
+}

--- a/src/Beckett/Database/ServiceCollectionExtensions.cs
+++ b/src/Beckett/Database/ServiceCollectionExtensions.cs
@@ -12,6 +12,8 @@ public static class ServiceCollectionExtensions
     {
         services.AddSingleton(options.Postgres);
 
+        Query.Initialize(options.Postgres);
+
         services.AddSingleton<IPostgresDataSource, PostgresDataSource>();
 
         services.AddSingleton<IPostgresDatabase, PostgresDatabase>();

--- a/src/Beckett/Scheduling/MessageScheduler.cs
+++ b/src/Beckett/Scheduling/MessageScheduler.cs
@@ -9,13 +9,12 @@ namespace Beckett.Scheduling;
 public class MessageScheduler(
     IPostgresDataSource dataSource,
     IPostgresDatabase database,
-    IInstrumentation instrumentation,
-    PostgresOptions options
+    IInstrumentation instrumentation
 ) : IMessageScheduler
 {
     public Task CancelScheduledMessage(Guid id, CancellationToken cancellationToken)
     {
-        return database.Execute(new CancelScheduledMessage(id, options), cancellationToken);
+        return database.Execute(new CancelScheduledMessage(id), cancellationToken);
     }
 
     public async Task<Guid> ScheduleMessage(
@@ -44,7 +43,7 @@ public class MessageScheduler(
         );
 
         await database.Execute(
-            new ScheduleMessage(streamName, scheduledMessage, options),
+            new ScheduleMessage(streamName, scheduledMessage),
             connection,
             cancellationToken
         );

--- a/src/Beckett/Scheduling/Queries/CancelScheduledMessage.cs
+++ b/src/Beckett/Scheduling/Queries/CancelScheduledMessage.cs
@@ -4,15 +4,17 @@ using NpgsqlTypes;
 
 namespace Beckett.Scheduling.Queries;
 
-public class CancelScheduledMessage(Guid id, PostgresOptions options) : IPostgresDatabaseQuery<int>
+public class CancelScheduledMessage(Guid id) : IPostgresDatabaseQuery<int>
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
-        command.CommandText = $"DELETE FROM {options.Schema}.scheduled_messages WHERE id = $1;";
+        const string sql = "DELETE FROM beckett.scheduled_messages WHERE id = $1;";
+
+        command.CommandText = Query.Build(nameof(CancelScheduledMessage), sql, out var prepare);
 
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Uuid });
 
-        if (options.PrepareStatements)
+        if (prepare)
         {
             await command.PrepareAsync(cancellationToken);
         }

--- a/src/Beckett/Scheduling/Queries/CancelScheduledMessage.cs
+++ b/src/Beckett/Scheduling/Queries/CancelScheduledMessage.cs
@@ -8,6 +8,7 @@ public class CancelScheduledMessage(Guid id) : IPostgresDatabaseQuery<int>
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = "DELETE FROM beckett.scheduled_messages WHERE id = $1;";
 
         command.CommandText = Query.Build(nameof(CancelScheduledMessage), sql, out var prepare);

--- a/src/Beckett/Scheduling/Queries/GetScheduledMessagesToDeliver.cs
+++ b/src/Beckett/Scheduling/Queries/GetScheduledMessagesToDeliver.cs
@@ -14,6 +14,7 @@ public class GetScheduledMessagesToDeliver(
         CancellationToken cancellationToken
     )
     {
+        //language=sql
         const string sql = """
             WITH messages_to_deliver AS (
                 DELETE FROM beckett.scheduled_messages

--- a/src/Beckett/Scheduling/Queries/ScheduleMessage.cs
+++ b/src/Beckett/Scheduling/Queries/ScheduleMessage.cs
@@ -7,14 +7,13 @@ namespace Beckett.Scheduling.Queries;
 
 public class ScheduleMessage(
     string streamName,
-    ScheduledMessageType scheduledMessage,
-    PostgresOptions options
+    ScheduledMessageType scheduledMessage
 ) : IPostgresDatabaseQuery<int>
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
-        command.CommandText = $"""
-            INSERT INTO {options.Schema}.scheduled_messages (
+        const string sql = """
+            INSERT INTO beckett.scheduled_messages (
               id,
               stream_name,
               type,
@@ -33,6 +32,8 @@ public class ScheduleMessage(
             ON CONFLICT (id) DO NOTHING;
         """;
 
+        command.CommandText = Query.Build(nameof(ScheduleMessage), sql, out var prepare);
+
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Uuid });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
@@ -40,7 +41,7 @@ public class ScheduleMessage(
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Jsonb });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.TimestampTz });
 
-        if (options.PrepareStatements)
+        if (prepare)
         {
             await command.PrepareAsync(cancellationToken);
         }

--- a/src/Beckett/Scheduling/Queries/ScheduleMessage.cs
+++ b/src/Beckett/Scheduling/Queries/ScheduleMessage.cs
@@ -12,6 +12,7 @@ public class ScheduleMessage(
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             INSERT INTO beckett.scheduled_messages (
               id,

--- a/src/Beckett/Scheduling/Services/ScheduledMessageService.cs
+++ b/src/Beckett/Scheduling/Services/ScheduledMessageService.cs
@@ -30,7 +30,7 @@ public class ScheduledMessageService(
                 await using var transaction = await connection.BeginTransactionAsync(stoppingToken);
 
                 var results = await database.Execute(
-                    new GetScheduledMessagesToDeliver(options.Scheduling.BatchSize, options.Postgres),
+                    new GetScheduledMessagesToDeliver(options.Scheduling.BatchSize),
                     connection,
                     transaction,
                     stoppingToken

--- a/src/Beckett/Storage/Postgres/PostgresMessageStorage.cs
+++ b/src/Beckett/Storage/Postgres/PostgresMessageStorage.cs
@@ -4,7 +4,7 @@ using Beckett.Storage.Postgres.Queries;
 
 namespace Beckett.Storage.Postgres;
 
-public class PostgresMessageStorage(IPostgresDataSource dataSource, IPostgresDatabase database, PostgresOptions options)
+public class PostgresMessageStorage(IPostgresDataSource dataSource, IPostgresDatabase database)
     : IMessageStorage
 {
     public async Task<AppendToStreamResult> AppendToStream(
@@ -21,7 +21,7 @@ public class PostgresMessageStorage(IPostgresDataSource dataSource, IPostgresDat
         await connection.OpenAsync(cancellationToken);
 
         var streamVersion = await database.Execute(
-            new AppendToStream(streamName, expectedVersion.Value, newMessages, options),
+            new AppendToStream(streamName, expectedVersion.Value, newMessages),
             connection,
             cancellationToken
         );
@@ -38,7 +38,7 @@ public class PostgresMessageStorage(IPostgresDataSource dataSource, IPostgresDat
 
         await connection.OpenAsync(cancellationToken);
 
-        var results = await database.Execute(new ReadGlobalStream(readOptions, options), connection, cancellationToken);
+        var results = await database.Execute(new ReadGlobalStream(readOptions), connection, cancellationToken);
 
         var items = new List<GlobalStreamMessage>();
 
@@ -75,7 +75,7 @@ public class PostgresMessageStorage(IPostgresDataSource dataSource, IPostgresDat
         await connection.OpenAsync(cancellationToken);
 
         var result = await database.Execute(
-            new ReadStream(streamName, readOptions, options),
+            new ReadStream(streamName, readOptions),
             cancellationToken
         );
 

--- a/src/Beckett/Storage/Postgres/Queries/AppendToStream.cs
+++ b/src/Beckett/Storage/Postgres/Queries/AppendToStream.cs
@@ -8,21 +8,22 @@ namespace Beckett.Storage.Postgres.Queries;
 public class AppendToStream(
     string streamName,
     long expectedVersion,
-    MessageType[] messages,
-    PostgresOptions options
+    MessageType[] messages
 ) : IPostgresDatabaseQuery<long>
 {
     public async Task<long> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
         try
         {
-            command.CommandText = $"select {options.Schema}.append_to_stream($1, $2, $3);";
+            const string sql = "select beckett.append_to_stream($1, $2, $3);";
+
+            command.CommandText = Query.Build(nameof(AppendToStream), sql, out var prepare);
 
             command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
             command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Bigint });
-            command.Parameters.Add(new NpgsqlParameter { DataTypeName = DataTypeNames.MessageArray(options.Schema) });
+            command.Parameters.Add(new NpgsqlParameter { DataTypeName = DataTypeNames.MessageArray("beckett") });
 
-            if (options.PrepareStatements)
+            if (prepare)
             {
                 await command.PrepareAsync(cancellationToken);
             }

--- a/src/Beckett/Storage/Postgres/Queries/AppendToStream.cs
+++ b/src/Beckett/Storage/Postgres/Queries/AppendToStream.cs
@@ -15,6 +15,7 @@ public class AppendToStream(
     {
         try
         {
+            //language=sql
             const string sql = "select beckett.append_to_stream($1, $2, $3);";
 
             command.CommandText = Query.Build(nameof(AppendToStream), sql, out var prepare);

--- a/src/Beckett/Storage/Postgres/Queries/ReadGlobalStream.cs
+++ b/src/Beckett/Storage/Postgres/Queries/ReadGlobalStream.cs
@@ -10,6 +10,7 @@ public class ReadGlobalStream(
 {
     public async Task<IReadOnlyList<Result>> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             WITH transaction_id AS (
                 SELECT m.transaction_id

--- a/src/Beckett/Storage/Postgres/Queries/ReadStream.cs
+++ b/src/Beckett/Storage/Postgres/Queries/ReadStream.cs
@@ -15,6 +15,7 @@ public class ReadStream(
         CancellationToken cancellationToken
     )
     {
+        //language=sql
         const string sql = """
             WITH stream_version AS (
                 SELECT max(stream_position) AS stream_version

--- a/src/Beckett/Storage/Postgres/Queries/ReadStream.cs
+++ b/src/Beckett/Storage/Postgres/Queries/ReadStream.cs
@@ -7,8 +7,7 @@ namespace Beckett.Storage.Postgres.Queries;
 
 public class ReadStream(
     string streamName,
-    ReadStreamOptions readOptions,
-    PostgresOptions postgresOptions
+    ReadStreamOptions readOptions
 ) : IPostgresDatabaseQuery<ReadStream.Result>
 {
     public async Task<Result> Execute(
@@ -16,10 +15,10 @@ public class ReadStream(
         CancellationToken cancellationToken
     )
     {
-        command.CommandText = $"""
+        const string sql = """
             WITH stream_version AS (
                 SELECT max(stream_position) AS stream_version
-                FROM {postgresOptions.Schema}.messages
+                FROM beckett.messages
                 WHERE stream_name = $1
                 AND archived = false
             ),
@@ -32,7 +31,7 @@ public class ReadStream(
                        data,
                        metadata,
                        timestamp
-                FROM {postgresOptions.Schema}.messages
+                FROM beckett.messages
                 WHERE stream_name = $1
                 AND ($2 IS NULL OR stream_position >= $2)
                 AND ($3 IS NULL OR stream_position <= $3)
@@ -64,6 +63,8 @@ public class ReadStream(
             FROM results;
         """;
 
+        command.CommandText = Query.Build(nameof(ReadStream), sql, out var prepare);
+
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Bigint, IsNullable = true });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Bigint, IsNullable = true });
@@ -75,7 +76,7 @@ public class ReadStream(
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Boolean });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Integer, IsNullable = true });
 
-        if (postgresOptions.PrepareStatements)
+        if (prepare)
         {
             await command.PrepareAsync(cancellationToken);
         }

--- a/src/Beckett/Subscriptions/CheckpointConsumer.cs
+++ b/src/Beckett/Subscriptions/CheckpointConsumer.cs
@@ -32,8 +32,7 @@ public class CheckpointConsumer(
                     new ReserveNextAvailableCheckpoint(
                         group.Name,
                         group.ReservationTimeout,
-                        options.Subscriptions.ReplayMode,
-                        options.Postgres
+                        options.Subscriptions.ReplayMode
                     ),
                     stoppingToken
                 );
@@ -50,7 +49,7 @@ public class CheckpointConsumer(
                     logger.CheckpointAlreadyCaughtUp(checkpoint.Id, checkpoint.StreamPosition, instance, group.Name);
 
                     await database.Execute(
-                        new ReleaseCheckpointReservation(checkpoint.Id, options.Postgres),
+                        new ReleaseCheckpointReservation(checkpoint.Id),
                         CancellationToken.None
                     );
 
@@ -70,7 +69,7 @@ public class CheckpointConsumer(
                     );
 
                     await database.Execute(
-                        new ReleaseCheckpointReservation(checkpoint.Id, options.Postgres),
+                        new ReleaseCheckpointReservation(checkpoint.Id),
                         CancellationToken.None
                     );
 

--- a/src/Beckett/Subscriptions/CheckpointProcessor.cs
+++ b/src/Beckett/Subscriptions/CheckpointProcessor.cs
@@ -13,7 +13,6 @@ public class CheckpointProcessor(
     IPostgresDataSource dataSource,
     IPostgresDatabase database,
     IServiceProvider serviceProvider,
-    BeckettOptions options,
     IInstrumentation instrumentation,
     ILogger<CheckpointProcessor> logger
 ) : ICheckpointProcessor
@@ -37,7 +36,7 @@ public class CheckpointProcessor(
                 await using var transaction = await connection.BeginTransactionAsync(CancellationToken.None);
 
                 await database.Execute(
-                    new UpdateCheckpointPosition(checkpoint.Id, success.StreamPosition, null, options.Postgres),
+                    new UpdateCheckpointPosition(checkpoint.Id, success.StreamPosition, null),
                     connection,
                     transaction,
                     CancellationToken.None
@@ -48,7 +47,7 @@ public class CheckpointProcessor(
                     if (success.GlobalPosition >= checkpoint.ReplayTargetPosition.Value)
                     {
                         await database.Execute(
-                            new SetSubscriptionToActive(subscription.Group.Name, subscription.Name, options.Postgres),
+                            new SetSubscriptionToActive(subscription.Group.Name, subscription.Name),
                             connection,
                             transaction,
                             CancellationToken.None
@@ -87,8 +86,7 @@ public class CheckpointProcessor(
                         status,
                         attempt,
                         ExceptionData.From(error.Exception).ToJson(),
-                        processAt,
-                        options.Postgres
+                        processAt
                     ),
                     CancellationToken.None
                 );

--- a/src/Beckett/Subscriptions/GlobalStreamConsumer.cs
+++ b/src/Beckett/Subscriptions/GlobalStreamConsumer.cs
@@ -13,7 +13,6 @@ public class GlobalStreamConsumer(
     IPostgresDataSource dataSource,
     IPostgresDatabase database,
     IMessageStorage messageStorage,
-    PostgresOptions postgresOptions,
     ILogger<GlobalStreamConsumer> logger
 )
 {
@@ -37,8 +36,7 @@ public class GlobalStreamConsumer(
                     new LockCheckpoint(
                         group.Name,
                         GlobalCheckpoint.Name,
-                        GlobalCheckpoint.StreamName,
-                        postgresOptions
+                        GlobalCheckpoint.StreamName
                     ),
                     connection,
                     transaction,
@@ -105,7 +103,7 @@ public class GlobalStreamConsumer(
                 if (checkpoints.Count > 0)
                 {
                     await database.Execute(
-                        new RecordCheckpoints(checkpoints.ToArray(), postgresOptions),
+                        new RecordCheckpoints(checkpoints.ToArray()),
                         connection,
                         transaction,
                         stoppingToken
@@ -121,7 +119,7 @@ public class GlobalStreamConsumer(
                 var newGlobalPosition = batch.StreamMessages.Max(x => x.GlobalPosition);
 
                 await database.Execute(
-                    new UpdateSystemCheckpointPosition(checkpoint.Id, newGlobalPosition, postgresOptions),
+                    new UpdateSystemCheckpointPosition(checkpoint.Id, newGlobalPosition),
                     connection,
                     transaction,
                     stoppingToken

--- a/src/Beckett/Subscriptions/Initialization/SubscriptionInitializer.cs
+++ b/src/Beckett/Subscriptions/Initialization/SubscriptionInitializer.cs
@@ -31,7 +31,7 @@ public class SubscriptionInitializer(
             await connection.OpenAsync(cancellationToken);
 
             var subscriptionName = await database.Execute(
-                new GetNextUninitializedSubscription(group.Name, options.Postgres),
+                new GetNextUninitializedSubscription(group.Name),
                 connection,
                 cancellationToken
             );
@@ -54,8 +54,7 @@ public class SubscriptionInitializer(
                     new SetSubscriptionStatus(
                         group.Name,
                         subscriptionName,
-                        SubscriptionStatus.Unknown,
-                        options.Postgres
+                        SubscriptionStatus.Unknown
                     ),
                     connection,
                     cancellationToken
@@ -84,8 +83,7 @@ public class SubscriptionInitializer(
                 new LockCheckpoint(
                     subscription.Group.Name,
                     subscription.Name,
-                    InitializationConstants.StreamName,
-                    options.Postgres
+                    InitializationConstants.StreamName
                 ),
                 connection,
                 transaction,
@@ -114,8 +112,7 @@ public class SubscriptionInitializer(
                     new LockCheckpoint(
                         subscription.Group.Name,
                         GlobalCheckpoint.Name,
-                        GlobalCheckpoint.StreamName,
-                        options.Postgres
+                        GlobalCheckpoint.StreamName
                     ),
                     connection,
                     transaction,
@@ -164,8 +161,7 @@ public class SubscriptionInitializer(
                     var checkpointCount = await database.Execute(
                         new GetSubscriptionCheckpointCount(
                             subscription.Group.Name,
-                            subscription.Name,
-                            options.Postgres
+                            subscription.Name
                         ),
                         cancellationToken
                     );
@@ -178,8 +174,7 @@ public class SubscriptionInitializer(
                     await database.Execute(
                         new SetSubscriptionToReplay(
                             subscription.Group.Name,
-                            subscription.Name,
-                            options.Postgres
+                            subscription.Name
                         ),
                         connection,
                         transaction,
@@ -197,8 +192,7 @@ public class SubscriptionInitializer(
                             count = await database.Execute(
                                 new AdvanceLaggingSubscriptionCheckpoints(
                                     subscription.Group.Name,
-                                    subscription.Name,
-                                    options.Postgres
+                                    subscription.Name
                                 ),
                                 connection,
                                 transaction,
@@ -210,8 +204,7 @@ public class SubscriptionInitializer(
                     await database.Execute(
                         new SetSubscriptionToActive(
                             subscription.Group.Name,
-                            subscription.Name,
-                            options.Postgres
+                            subscription.Name
                         ),
                         connection,
                         transaction,
@@ -263,7 +256,7 @@ public class SubscriptionInitializer(
             }
 
             await database.Execute(
-                new RecordCheckpoints(checkpoints.ToArray(), options.Postgres),
+                new RecordCheckpoints(checkpoints.ToArray()),
                 connection,
                 transaction,
                 cancellationToken
@@ -274,8 +267,7 @@ public class SubscriptionInitializer(
             await database.Execute(
                 new UpdateSystemCheckpointPosition(
                     checkpoint.Id,
-                    newGlobalPosition,
-                    options.Postgres
+                    newGlobalPosition
                 ),
                 connection,
                 transaction,
@@ -286,8 +278,7 @@ public class SubscriptionInitializer(
                 new UpdateSubscriptionReplayTargetPosition(
                     subscription.Group.Name,
                     subscription.Name,
-                    replayTargetPosition.GetValueOrDefault(),
-                    options.Postgres
+                    replayTargetPosition.GetValueOrDefault()
                 ),
                 connection,
                 transaction,

--- a/src/Beckett/Subscriptions/Queries/AddOrUpdateSubscription.cs
+++ b/src/Beckett/Subscriptions/Queries/AddOrUpdateSubscription.cs
@@ -11,6 +11,7 @@ public class AddOrUpdateSubscription(
 {
     public async Task<SubscriptionStatus> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             WITH insert_subscription AS (
                 INSERT INTO beckett.subscriptions (group_name, name)

--- a/src/Beckett/Subscriptions/Queries/AdvanceLaggingSubscriptionCheckpoints.cs
+++ b/src/Beckett/Subscriptions/Queries/AdvanceLaggingSubscriptionCheckpoints.cs
@@ -8,6 +8,7 @@ public class AdvanceLaggingSubscriptionCheckpoints(string groupName, string name
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             UPDATE beckett.checkpoints
             SET stream_position = stream_version,

--- a/src/Beckett/Subscriptions/Queries/EnsureCheckpointExists.cs
+++ b/src/Beckett/Subscriptions/Queries/EnsureCheckpointExists.cs
@@ -12,6 +12,7 @@ public class EnsureCheckpointExists(
 {
     public async Task<long> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             WITH new_checkpoint AS (
                 INSERT INTO beckett.checkpoints (group_name, name, stream_name)

--- a/src/Beckett/Subscriptions/Queries/EnsureCheckpointExists.cs
+++ b/src/Beckett/Subscriptions/Queries/EnsureCheckpointExists.cs
@@ -7,21 +7,20 @@ namespace Beckett.Subscriptions.Queries;
 public class EnsureCheckpointExists(
     string groupName,
     string name,
-    string streamName,
-    PostgresOptions options
+    string streamName
 ) : IPostgresDatabaseQuery<long>
 {
     public async Task<long> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
-        command.CommandText = $"""
+        const string sql = """
             WITH new_checkpoint AS (
-                INSERT INTO {options.Schema}.checkpoints (group_name, name, stream_name)
+                INSERT INTO beckett.checkpoints (group_name, name, stream_name)
                 VALUES ($1, $2, $3)
                 ON CONFLICT (group_name, name, stream_name) DO NOTHING
                 RETURNING 0 as stream_version
             )
             SELECT stream_version
-            FROM {options.Schema}.checkpoints
+            FROM beckett.checkpoints
             WHERE group_name = $1
             AND name = $2
             AND stream_name = $3
@@ -30,11 +29,13 @@ public class EnsureCheckpointExists(
             FROM new_checkpoint;
         """;
 
+        command.CommandText = Query.Build(nameof(EnsureCheckpointExists), sql, out var prepare);
+
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
 
-        if (options.PrepareStatements)
+        if (prepare)
         {
             await command.PrepareAsync(cancellationToken);
         }

--- a/src/Beckett/Subscriptions/Queries/GetNextUninitializedSubscription.cs
+++ b/src/Beckett/Subscriptions/Queries/GetNextUninitializedSubscription.cs
@@ -8,6 +8,7 @@ public class GetNextUninitializedSubscription(string groupName) : IPostgresDatab
 {
     public async Task<string?> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             SELECT name
             FROM beckett.subscriptions

--- a/src/Beckett/Subscriptions/Queries/GetNextUninitializedSubscription.cs
+++ b/src/Beckett/Subscriptions/Queries/GetNextUninitializedSubscription.cs
@@ -4,24 +4,23 @@ using NpgsqlTypes;
 
 namespace Beckett.Subscriptions.Queries;
 
-public class GetNextUninitializedSubscription(
-    string groupName,
-    PostgresOptions options
-) : IPostgresDatabaseQuery<string?>
+public class GetNextUninitializedSubscription(string groupName) : IPostgresDatabaseQuery<string?>
 {
     public async Task<string?> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
-        command.CommandText = $"""
+        const string sql = """
             SELECT name
-            FROM {options.Schema}.subscriptions
+            FROM beckett.subscriptions
             WHERE group_name = $1
             AND status in ('uninitialized', 'backfill')
             LIMIT 1;
         """;
 
+        command.CommandText = Query.Build(nameof(GetNextUninitializedSubscription), sql, out var prepare);
+
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
 
-        if (options.PrepareStatements)
+        if (prepare)
         {
             await command.PrepareAsync(cancellationToken);
         }

--- a/src/Beckett/Subscriptions/Queries/GetSubscriptionCheckpointCount.cs
+++ b/src/Beckett/Subscriptions/Queries/GetSubscriptionCheckpointCount.cs
@@ -11,6 +11,7 @@ public class GetSubscriptionCheckpointCount(
 {
     public async Task<long> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             SELECT count(*)
             FROM beckett.checkpoints

--- a/src/Beckett/Subscriptions/Queries/LockCheckpoint.cs
+++ b/src/Beckett/Subscriptions/Queries/LockCheckpoint.cs
@@ -12,6 +12,7 @@ public class LockCheckpoint(
 {
     public async Task<Result?> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             SELECT id, stream_position
             FROM beckett.checkpoints

--- a/src/Beckett/Subscriptions/Queries/LockCheckpoint.cs
+++ b/src/Beckett/Subscriptions/Queries/LockCheckpoint.cs
@@ -7,15 +7,14 @@ namespace Beckett.Subscriptions.Queries;
 public class LockCheckpoint(
     string groupName,
     string name,
-    string streamName,
-    PostgresOptions options
+    string streamName
 ) : IPostgresDatabaseQuery<LockCheckpoint.Result?>
 {
     public async Task<Result?> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
-        command.CommandText = $"""
+        const string sql = """
             SELECT id, stream_position
-            FROM {options.Schema}.checkpoints
+            FROM beckett.checkpoints
             WHERE group_name = $1
             AND name = $2
             AND stream_name = $3
@@ -23,11 +22,13 @@ public class LockCheckpoint(
             SKIP LOCKED;
         """;
 
+        command.CommandText = Query.Build(nameof(LockCheckpoint), sql, out var prepare);
+
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
 
-        if (options.PrepareStatements)
+        if (prepare)
         {
             await command.PrepareAsync(cancellationToken);
         }

--- a/src/Beckett/Subscriptions/Queries/RecordCheckpointError.cs
+++ b/src/Beckett/Subscriptions/Queries/RecordCheckpointError.cs
@@ -17,6 +17,7 @@ public record RecordCheckpointError(
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             UPDATE beckett.checkpoints
             SET stream_position = $2,

--- a/src/Beckett/Subscriptions/Queries/RecordCheckpoints.cs
+++ b/src/Beckett/Subscriptions/Queries/RecordCheckpoints.cs
@@ -8,6 +8,7 @@ public class RecordCheckpoints(CheckpointType[] checkpoints) : IPostgresDatabase
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             INSERT INTO beckett.checkpoints (stream_version, stream_position, group_name, name, stream_name)
             SELECT c.stream_version, c.stream_position, c.group_name, c.name, c.stream_name

--- a/src/Beckett/Subscriptions/Queries/RecordCheckpoints.cs
+++ b/src/Beckett/Subscriptions/Queries/RecordCheckpoints.cs
@@ -4,21 +4,23 @@ using Npgsql;
 
 namespace Beckett.Subscriptions.Queries;
 
-public class RecordCheckpoints(CheckpointType[] checkpoints, PostgresOptions options) : IPostgresDatabaseQuery<int>
+public class RecordCheckpoints(CheckpointType[] checkpoints) : IPostgresDatabaseQuery<int>
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
-        command.CommandText = $"""
-            INSERT INTO {options.Schema}.checkpoints (stream_version, stream_position, group_name, name, stream_name)
+        const string sql = """
+            INSERT INTO beckett.checkpoints (stream_version, stream_position, group_name, name, stream_name)
             SELECT c.stream_version, c.stream_position, c.group_name, c.name, c.stream_name
             FROM unnest($1) c
             ON CONFLICT (group_name, name, stream_name) DO UPDATE
                 SET stream_version = excluded.stream_version;
         """;
 
-        command.Parameters.Add(new NpgsqlParameter { DataTypeName = DataTypeNames.CheckpointArray(options.Schema) });
+        command.CommandText = Query.Build(nameof(RecordCheckpoints), sql, out var prepare);
 
-        if (options.PrepareStatements)
+        command.Parameters.Add(new NpgsqlParameter { DataTypeName = DataTypeNames.CheckpointArray("beckett") });
+
+        if (prepare)
         {
             await command.PrepareAsync(cancellationToken);
         }

--- a/src/Beckett/Subscriptions/Queries/RecordStreamData.cs
+++ b/src/Beckett/Subscriptions/Queries/RecordStreamData.cs
@@ -12,6 +12,7 @@ public class RecordStreamData(
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             WITH insert_categories AS (
                 INSERT INTO beckett.categories (name, updated_at)

--- a/src/Beckett/Subscriptions/Queries/RecoverExpiredCheckpointReservations.cs
+++ b/src/Beckett/Subscriptions/Queries/RecoverExpiredCheckpointReservations.cs
@@ -6,18 +6,17 @@ namespace Beckett.Subscriptions.Queries;
 
 public class RecoverExpiredCheckpointReservations(
     string groupName,
-    int batchSize,
-    PostgresOptions options
+    int batchSize
 ) : IPostgresDatabaseQuery<int>
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
-        command.CommandText = $"""
-            UPDATE {options.Schema}.checkpoints c
+        const string sql = """
+            UPDATE beckett.checkpoints c
             SET reserved_until = NULL
             FROM (
                 SELECT id
-                FROM {options.Schema}.checkpoints
+                FROM beckett.checkpoints
                 WHERE group_name = $1
                 AND reserved_until <= now()
                 FOR UPDATE SKIP LOCKED
@@ -26,10 +25,12 @@ public class RecoverExpiredCheckpointReservations(
             WHERE c.id = d.id;
         """;
 
+        command.CommandText = Query.Build(nameof(RecoverExpiredCheckpointReservations), sql, out var prepare);
+
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Integer });
 
-        if (options.PrepareStatements)
+        if (prepare)
         {
             await command.PrepareAsync(cancellationToken);
         }

--- a/src/Beckett/Subscriptions/Queries/RecoverExpiredCheckpointReservations.cs
+++ b/src/Beckett/Subscriptions/Queries/RecoverExpiredCheckpointReservations.cs
@@ -11,6 +11,7 @@ public class RecoverExpiredCheckpointReservations(
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             UPDATE beckett.checkpoints c
             SET reserved_until = NULL

--- a/src/Beckett/Subscriptions/Queries/ReleaseCheckpointReservation.cs
+++ b/src/Beckett/Subscriptions/Queries/ReleaseCheckpointReservation.cs
@@ -10,6 +10,7 @@ public class ReleaseCheckpointReservation(
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             UPDATE beckett.checkpoints
             SET process_at = NULL,

--- a/src/Beckett/Subscriptions/Queries/ReleaseCheckpointReservation.cs
+++ b/src/Beckett/Subscriptions/Queries/ReleaseCheckpointReservation.cs
@@ -5,22 +5,23 @@ using NpgsqlTypes;
 namespace Beckett.Subscriptions.Queries;
 
 public class ReleaseCheckpointReservation(
-    long id,
-    PostgresOptions options
+    long id
 ) : IPostgresDatabaseQuery<int>
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
-        command.CommandText = $"""
-            UPDATE {options.Schema}.checkpoints
+        const string sql = """
+            UPDATE beckett.checkpoints
             SET process_at = NULL,
                 reserved_until = NULL
             WHERE id = $1;
         """;
 
+        command.CommandText = Query.Build(nameof(ReleaseCheckpointReservation), sql, out var prepare);
+
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Bigint });
 
-        if (options.PrepareStatements)
+        if (prepare)
         {
             await command.PrepareAsync(cancellationToken);
         }

--- a/src/Beckett/Subscriptions/Queries/ReserveNextAvailableCheckpoint.cs
+++ b/src/Beckett/Subscriptions/Queries/ReserveNextAvailableCheckpoint.cs
@@ -12,6 +12,7 @@ public class ReserveNextAvailableCheckpoint(
 {
     public async Task<Checkpoint?> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             UPDATE beckett.checkpoints c
             SET reserved_until = now() + $2

--- a/src/Beckett/Subscriptions/Queries/SetSubscriptionStatus.cs
+++ b/src/Beckett/Subscriptions/Queries/SetSubscriptionStatus.cs
@@ -13,6 +13,7 @@ public class SetSubscriptionStatus(
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             UPDATE beckett.subscriptions
             SET status = $3

--- a/src/Beckett/Subscriptions/Queries/SetSubscriptionStatus.cs
+++ b/src/Beckett/Subscriptions/Queries/SetSubscriptionStatus.cs
@@ -8,24 +8,25 @@ namespace Beckett.Subscriptions.Queries;
 public class SetSubscriptionStatus(
     string groupName,
     string name,
-    SubscriptionStatus status,
-    PostgresOptions options
+    SubscriptionStatus status
 ) : IPostgresDatabaseQuery<int>
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
-        command.CommandText = $"""
-            UPDATE {options.Schema}.subscriptions
+        const string sql = """
+            UPDATE beckett.subscriptions
             SET status = $3
             WHERE group_name = $1
             AND name = $2;
         """;
 
-        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
-        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
-        command.Parameters.Add(new NpgsqlParameter { DataTypeName = DataTypeNames.SubscriptionStatus(options.Schema) });
+        command.CommandText = Query.Build(nameof(SetSubscriptionStatus), sql, out var prepare);
 
-        if (options.PrepareStatements)
+        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
+        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
+        command.Parameters.Add(new NpgsqlParameter { DataTypeName = DataTypeNames.SubscriptionStatus("beckett") });
+
+        if (prepare)
         {
             await command.PrepareAsync(cancellationToken);
         }

--- a/src/Beckett/Subscriptions/Queries/SetSubscriptionToActive.cs
+++ b/src/Beckett/Subscriptions/Queries/SetSubscriptionToActive.cs
@@ -11,6 +11,7 @@ public class SetSubscriptionToActive(
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             WITH delete_initialization_checkpoint AS (
                 DELETE FROM beckett.checkpoints

--- a/src/Beckett/Subscriptions/Queries/SetSubscriptionToReplay.cs
+++ b/src/Beckett/Subscriptions/Queries/SetSubscriptionToReplay.cs
@@ -6,29 +6,30 @@ namespace Beckett.Subscriptions.Queries;
 
 public class SetSubscriptionToReplay(
     string groupName,
-    string name,
-    PostgresOptions options
+    string name
 ) : IPostgresDatabaseQuery<int>
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
-        command.CommandText = $"""
+        const string sql = """
             WITH delete_initialization_checkpoint AS (
-                DELETE FROM {options.Schema}.checkpoints
+                DELETE FROM beckett.checkpoints
                 WHERE group_name = $1
                 AND name = $2
                 AND stream_name = '$initializing'
             )
-            UPDATE {options.Schema}.subscriptions
+            UPDATE beckett.subscriptions
             SET status = 'replay'
             WHERE group_name = $1
             AND name = $2;
         """;
 
+        command.CommandText = Query.Build(nameof(SetSubscriptionToReplay), sql, out var prepare);
+
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
 
-        if (options.PrepareStatements)
+        if (prepare)
         {
             await command.PrepareAsync(cancellationToken);
         }

--- a/src/Beckett/Subscriptions/Queries/SetSubscriptionToReplay.cs
+++ b/src/Beckett/Subscriptions/Queries/SetSubscriptionToReplay.cs
@@ -11,6 +11,7 @@ public class SetSubscriptionToReplay(
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             WITH delete_initialization_checkpoint AS (
                 DELETE FROM beckett.checkpoints

--- a/src/Beckett/Subscriptions/Queries/UpdateCheckpointPosition.cs
+++ b/src/Beckett/Subscriptions/Queries/UpdateCheckpointPosition.cs
@@ -12,6 +12,7 @@ public class UpdateCheckpointPosition(
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             UPDATE beckett.checkpoints
             SET stream_position = $2,

--- a/src/Beckett/Subscriptions/Queries/UpdateSubscriptionReplayTargetPosition.cs
+++ b/src/Beckett/Subscriptions/Queries/UpdateSubscriptionReplayTargetPosition.cs
@@ -7,24 +7,25 @@ namespace Beckett.Subscriptions.Queries;
 public class UpdateSubscriptionReplayTargetPosition(
     string groupName,
     string name,
-    long position,
-    PostgresOptions options
+    long position
 ) : IPostgresDatabaseQuery<int>
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
-        command.CommandText = $"""
-            UPDATE {options.Schema}.subscriptions
+        const string sql = """
+            UPDATE beckett.subscriptions
             SET replay_target_position = $3
             WHERE group_name = $1
             AND name = $2;
         """;
 
+        command.CommandText = Query.Build(nameof(UpdateSubscriptionReplayTargetPosition), sql, out var prepare);
+
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Bigint });
 
-        if (options.PrepareStatements)
+        if (prepare)
         {
             await command.PrepareAsync(cancellationToken);
         }

--- a/src/Beckett/Subscriptions/Queries/UpdateSubscriptionReplayTargetPosition.cs
+++ b/src/Beckett/Subscriptions/Queries/UpdateSubscriptionReplayTargetPosition.cs
@@ -12,6 +12,7 @@ public class UpdateSubscriptionReplayTargetPosition(
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             UPDATE beckett.subscriptions
             SET replay_target_position = $3

--- a/src/Beckett/Subscriptions/Queries/UpdateSystemCheckpointPosition.cs
+++ b/src/Beckett/Subscriptions/Queries/UpdateSystemCheckpointPosition.cs
@@ -6,23 +6,24 @@ namespace Beckett.Subscriptions.Queries;
 
 public class UpdateSystemCheckpointPosition(
     long id,
-    long position,
-    PostgresOptions options
+    long position
 ) : IPostgresDatabaseQuery<int>
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
-        command.CommandText = $"""
-            UPDATE {options.Schema}.checkpoints
+        const string sql = """
+            UPDATE beckett.checkpoints
             SET stream_version = $2,
                 stream_position = $2
             WHERE id = $1;
         """;
 
+        command.CommandText = Query.Build(nameof(UpdateSystemCheckpointPosition), sql, out var prepare);
+
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Bigint });
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Bigint });
 
-        if (options.PrepareStatements)
+        if (prepare)
         {
             await command.PrepareAsync(cancellationToken);
         }

--- a/src/Beckett/Subscriptions/Queries/UpdateSystemCheckpointPosition.cs
+++ b/src/Beckett/Subscriptions/Queries/UpdateSystemCheckpointPosition.cs
@@ -11,6 +11,7 @@ public class UpdateSystemCheckpointPosition(
 {
     public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
     {
+        //language=sql
         const string sql = """
             UPDATE beckett.checkpoints
             SET stream_version = $2,

--- a/src/Beckett/Subscriptions/Services/BootstrapSubscriptions.cs
+++ b/src/Beckett/Subscriptions/Services/BootstrapSubscriptions.cs
@@ -46,8 +46,7 @@ public class BootstrapSubscriptions(
             new EnsureCheckpointExists(
                 group.Name,
                 GlobalCheckpoint.Name,
-                GlobalCheckpoint.StreamName,
-                options.Postgres
+                GlobalCheckpoint.StreamName
             ),
             connection,
             transaction,
@@ -69,8 +68,7 @@ public class BootstrapSubscriptions(
             var status = await database.Execute(
                 new AddOrUpdateSubscription(
                     group.Name,
-                    subscription.Name,
-                    options.Postgres
+                    subscription.Name
                 ),
                 connection,
                 transaction,
@@ -114,8 +112,7 @@ public class BootstrapSubscriptions(
                 await database.Execute(
                     new SetSubscriptionToActive(
                         group.Name,
-                        subscription.Name,
-                        options.Postgres
+                        subscription.Name
                     ),
                     connection,
                     transaction,
@@ -146,7 +143,7 @@ public class BootstrapSubscriptions(
         if (checkpoints.Count > 0)
         {
             await database.Execute(
-                new RecordCheckpoints(checkpoints.ToArray(), options.Postgres),
+                new RecordCheckpoints(checkpoints.ToArray()),
                 connection,
                 transaction,
                 stoppingToken

--- a/src/Beckett/Subscriptions/Services/GlobalStreamConsumerHost.cs
+++ b/src/Beckett/Subscriptions/Services/GlobalStreamConsumerHost.cs
@@ -31,7 +31,6 @@ public class GlobalStreamConsumerHost(
             dataSource,
             database,
             messageStorage,
-            options.Postgres,
             loggerFactory.CreateLogger<GlobalStreamConsumer>()
         );
     }

--- a/src/Beckett/Subscriptions/Services/RecoverExpiredCheckpointReservationsService.cs
+++ b/src/Beckett/Subscriptions/Services/RecoverExpiredCheckpointReservationsService.cs
@@ -29,8 +29,7 @@ public class RecoverExpiredCheckpointReservationsService(
                 var recovered = await database.Execute(
                     new RecoverExpiredCheckpointReservations(
                         group.Name,
-                        group.ReservationRecoveryBatchSize,
-                        options.Postgres
+                        group.ReservationRecoveryBatchSize
                     ),
                     stoppingToken
                 );

--- a/src/Beckett/Subscriptions/Services/StreamDataRecordingService.cs
+++ b/src/Beckett/Subscriptions/Services/StreamDataRecordingService.cs
@@ -7,7 +7,6 @@ namespace Beckett.Subscriptions.Services;
 
 public class StreamDataRecordingService(
     IPostgresDatabase database,
-    BeckettOptions options,
     ILogger<StreamDataRecordingService> logger
 ) : BackgroundService
 {
@@ -43,8 +42,7 @@ public class StreamDataRecordingService(
                     new RecordStreamData(
                         categories.Keys.ToArray(),
                         categories.Values.ToArray(),
-                        tenants.ToArray(),
-                        options.Postgres
+                        tenants.ToArray()
                     ),
                     CancellationToken.None
                 );


### PR DESCRIPTION
- convert SQL queries to constants using the `beckett` default schema
- if someone has a non-default schema configured, then the options will be applied to each query with the updated version cached for reuse