### PR TITLE
Consumer polling and task handling updates

### DIFF
--- a/src/Beckett/Subscriptions/CheckpointConsumerGroup.cs
+++ b/src/Beckett/Subscriptions/CheckpointConsumerGroup.cs
@@ -16,14 +16,14 @@ public class CheckpointConsumerGroup(
     public async Task Poll(CancellationToken stoppingToken)
     {
         var tasks = Enumerable.Range(1, group.GetConcurrency()).Select(
-            x => new CheckpointConsumer(
+            x => Task.Run(() => new CheckpointConsumer(
                 group,
                 channel,
                 database,
                 checkpointProcessor,
                 options,
                 loggerFactory.CreateLogger<CheckpointConsumer>()
-            ).Poll(x, stoppingToken)
+            ).Poll(x, stoppingToken), stoppingToken)
         ).ToArray();
 
         await Task.WhenAll(tasks);

--- a/src/Beckett/Subscriptions/Services/GlobalStreamConsumerHost.cs
+++ b/src/Beckett/Subscriptions/Services/GlobalStreamConsumerHost.cs
@@ -18,7 +18,7 @@ public class GlobalStreamConsumerHost(
     {
         var consumers = options.Subscriptions.Groups.Select(BuildConsumerForSubscriptionGroup);
 
-        var tasks = consumers.Select(x => x.Poll(stoppingToken)).ToArray();
+        var tasks = consumers.Select(x => Task.Run(() => x.Poll(stoppingToken), stoppingToken)).ToArray();
 
         await Task.WhenAll(tasks);
     }


### PR DESCRIPTION
- switch back to using `Task.Run` for consumer tasks
- switch from `ReadAllAsync` to `WaitToReadAsync` + `TryRead` pattern for reading from channels