### PR TITLE
Dashboard - Stream Messages View URL Decoding Fix

### DIFF
--- a/src/Beckett.Dashboard/MessageStore/Messages/MessagesEndpoint.cs
+++ b/src/Beckett.Dashboard/MessageStore/Messages/MessagesEndpoint.cs
@@ -21,7 +21,7 @@ public static class MessagesEndpoint
         var offset = Pagination.ToOffset(pageParameter, pageSizeParameter);
 
         var result = await database.Execute(
-            new MessagesQuery(streamName, query, offset, pageSizeParameter),
+            new MessagesQuery(decodedStreamName, query, offset, pageSizeParameter),
             cancellationToken
         );
 


### PR DESCRIPTION
- in order to handle non-URL-safe characters (slashes, etc...) use the URL-decoded stream name value when querying for messages in a stream