### PR TITLE
Append To Stream - Remove Locks, Query Optimization

### DIFF
--- a/src/Beckett/Database/PostgresDatabase.cs
+++ b/src/Beckett/Database/PostgresDatabase.cs
@@ -66,7 +66,8 @@ public class PostgresDatabase(IPostgresDataSource dataSource) : IPostgresDatabas
     private static readonly ResiliencePipeline Pipeline = new ResiliencePipelineBuilder().AddRetry(
         new RetryStrategyOptions
         {
-            ShouldHandle = new PredicateBuilder().Handle<NpgsqlException>(e => e.IsTransient),
+            ShouldHandle = new PredicateBuilder().Handle<StreamConcurrentWriteException>()
+                .Handle<NpgsqlException>(e => e.IsTransient),
             MaxRetryAttempts = 3,
             Delay = TimeSpan.FromMilliseconds(50),
             BackoffType = DelayBackoffType.Exponential,

--- a/src/Beckett/Storage/Postgres/PostgresExceptionExtensions.cs
+++ b/src/Beckett/Storage/Postgres/PostgresExceptionExtensions.cs
@@ -6,9 +6,15 @@ public static class PostgresExceptionExtensions
 {
     public static void HandleAppendToStreamError(this PostgresException exception)
     {
+        const string uniqueConstraintViolation = "23505";
         const string streamDoesNotExistText = "non-existing stream";
         const string streamAlreadyExistsText = "stream that already exists";
         const string expectedVersionText = "expected version";
+
+        if (exception.SqlState == uniqueConstraintViolation)
+        {
+            throw new StreamConcurrentWriteException(exception.MessageText);
+        }
 
         if (exception.MessageText.Contains(streamDoesNotExistText))
         {

--- a/src/Beckett/StreamConcurrentWriteException.cs
+++ b/src/Beckett/StreamConcurrentWriteException.cs
@@ -1,0 +1,20 @@
+namespace Beckett;
+
+/// <summary>
+/// Exception that is thrown when concurrent writes to the same stream occur, and one writer loses. The write will be
+/// retried immediately up to three times, after which the exception will bubble up. This primarily happens when using
+/// <see cref="ExpectedVersion.Any"/> or <see cref="ExpectedVersion.StreamExists"/> as the expected version when
+/// appending messages to a stream and as such it is recommended to favor specifying the expected version explicitly
+/// when appending messages to a stream or use <see cref="ExpectedVersion.StreamDoesNotExist"/> when starting a new
+/// stream.
+/// </summary>
+public class StreamConcurrentWriteException : Exception
+{
+    public StreamConcurrentWriteException()
+    {
+    }
+
+    public StreamConcurrentWriteException(string? message) : base(message)
+    {
+    }
+}


### PR DESCRIPTION
- remove locks from `AppendToStream` query
- update query to ensure that `pg_notify` call occurs and doesn't get optimized away
- add `StreamConcurrentWriteException` to handle concurrent write scenarios without locking