### PR TITLE
Retries - Track Attempts Counter Explicitly

### DIFF
--- a/db/migrations/001.sql
+++ b/db/migrations/001.sql
@@ -180,7 +180,7 @@ CREATE TABLE IF NOT EXISTS __schema__.checkpoints
   updated_at timestamp with time zone DEFAULT now(),
   process_at timestamp with time zone NULL,
   reserved_until timestamp with time zone NULL,
-  retry_attempts int GENERATED ALWAYS AS (coalesce(array_length(retries, 1), 0)) STORED,
+  retry_attempts int NOT NULL DEFAULT 0,
   lagging boolean GENERATED ALWAYS AS (stream_version > stream_position) STORED,
   status __schema__.checkpoint_status NOT NULL DEFAULT 'active',
   group_name text NOT NULL,

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 16.9
--- Dumped by pg_dump version 16.9
+-- Dumped from database version 16.2
+-- Dumped by pg_dump version 16.2
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -175,7 +175,7 @@ CREATE TABLE beckett.checkpoints (
     updated_at timestamp with time zone DEFAULT now(),
     process_at timestamp with time zone,
     reserved_until timestamp with time zone,
-    retry_attempts integer GENERATED ALWAYS AS (COALESCE(array_length(retries, 1), 0)) STORED,
+    retry_attempts integer DEFAULT 0 NOT NULL,
     lagging boolean GENERATED ALWAYS AS ((stream_version > stream_position)) STORED,
     status beckett.checkpoint_status DEFAULT 'active'::beckett.checkpoint_status NOT NULL,
     group_name text NOT NULL,

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/BulkSkip/BulkSkipQuery.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/BulkSkip/BulkSkipQuery.cs
@@ -17,6 +17,7 @@ public class BulkSkipQuery(
                 process_at = NULL,
                 reserved_until = NULL,
                 status = 'active',
+                retry_attempts = 0,
                 retries = NULL
             WHERE id = ANY($1);
         """;

--- a/src/Beckett.Dashboard/Subscriptions/Checkpoints/Skip/SkipQuery.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Checkpoints/Skip/SkipQuery.cs
@@ -17,6 +17,7 @@ public class SkipQuery(
                 process_at = NULL,
                 reserved_until = NULL,
                 status = 'active',
+                retry_attempts = 0,
                 retries = NULL
             WHERE id = $1;
         """;

--- a/src/Beckett/Subscriptions/CheckpointProcessor.cs
+++ b/src/Beckett/Subscriptions/CheckpointProcessor.cs
@@ -66,7 +66,7 @@ public class CheckpointProcessor(
 
                 var maxRetryCount = subscription.GetMaxRetryCount(exceptionType);
 
-                var attempt = checkpoint.IsRetryOrFailure ? checkpoint.RetryAttempts : 0;
+                var attempt = checkpoint.IsRetryOrFailure ? checkpoint.RetryAttempts + 1 : 0;
 
                 var status = attempt >= maxRetryCount ? CheckpointStatus.Failed : CheckpointStatus.Retry;
 

--- a/src/Beckett/Subscriptions/Queries/RecordCheckpointError.cs
+++ b/src/Beckett/Subscriptions/Queries/RecordCheckpointError.cs
@@ -21,13 +21,14 @@ public record RecordCheckpointError(
         const string sql = """
             UPDATE beckett.checkpoints
             SET stream_position = $2,
-            process_at = $6,
-            reserved_until = NULL,
-            status = $3,
-            retries = array_append(
-                coalesce(retries, array[]::beckett.retry[]),
-                row($4, $5, now())::beckett.retry
-            )
+                process_at = $6,
+                reserved_until = NULL,
+                status = $3,
+                retry_attempts = $4,
+                retries = array_append(
+                    coalesce(retries, array[]::beckett.retry[]),
+                    row($4, $5, now())::beckett.retry
+                )
             WHERE id = $1;
         """;
 

--- a/src/Beckett/Subscriptions/Queries/UpdateCheckpointPosition.cs
+++ b/src/Beckett/Subscriptions/Queries/UpdateCheckpointPosition.cs
@@ -19,6 +19,7 @@ public class UpdateCheckpointPosition(
                 process_at = $3,
                 reserved_until = NULL,
                 status = 'active',
+                retry_attempts = 0,
                 retries = NULL
             WHERE id = $1;
         """;


### PR DESCRIPTION
- track retry attempts explicitly instead of a generated column or trigger
  - the addition of an explicit retry_attempts column to existing systems cannot be added as a generated column and requires the use of a trigger - tracking the value explicitly removes the need for either approach