### PR TITLE
Subscription Initialization Improvements

### DIFF
--- a/db/versions/0.20.12.sql
+++ b/db/versions/0.20.12.sql
@@ -1,5 +1,5 @@
 -- Beckett v0.20.12
- 
+
 -- inline append query
 DROP FUNCTION IF EXISTS beckett.append_to_stream(text, bigint, beckett.message[]);
 
@@ -27,3 +27,183 @@ DROP INDEX IF EXISTS beckett.ix_messages_active_correlation_id;
 CREATE INDEX ix_messages_active_correlation_id_global_position
   ON beckett.messages_active ((metadata ->> '$correlation_id'::text), global_position)
   WHERE ((metadata ->> '$correlation_id'::text) IS NOT NULL);
+
+-- subscription utility functions
+CREATE OR REPLACE FUNCTION beckett.delete_subscription(
+  _group_name text,
+  _name text
+)
+  RETURNS void
+  LANGUAGE plpgsql
+AS
+$$
+DECLARE
+  _rows_deleted integer;
+BEGIN
+  LOOP
+    DELETE FROM beckett.checkpoints
+    WHERE id IN (
+      SELECT id
+      FROM beckett.checkpoints
+      WHERE group_name = _group_name
+      AND name = _name
+      LIMIT 500
+    );
+
+    GET DIAGNOSTICS _rows_deleted = ROW_COUNT;
+    EXIT WHEN _rows_deleted = 0;
+  END LOOP;
+
+  DELETE FROM beckett.subscriptions
+  WHERE group_name = _group_name
+  AND name = _name;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION beckett.move_subscription(
+  _group_name text,
+  _name text,
+  _new_group_name text
+)
+  RETURNS void
+  LANGUAGE plpgsql
+AS
+$$
+DECLARE
+  _rows_updated integer;
+BEGIN
+  UPDATE beckett.subscriptions
+  SET group_name = _new_group_name
+  WHERE group_name = _group_name
+  AND name = _name;
+
+  LOOP
+    UPDATE beckett.checkpoints
+    SET group_name = _new_group_name
+    WHERE id IN (
+      SELECT id
+      FROM beckett.checkpoints
+      WHERE group_name = _group_name
+      AND name = _name
+      LIMIT 500
+    );
+
+    GET DIAGNOSTICS _rows_updated = ROW_COUNT;
+    EXIT WHEN _rows_updated = 0;
+  END LOOP;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION beckett.rename_subscription(
+  _group_name text,
+  _name text,
+  _new_name text
+)
+  RETURNS void
+  LANGUAGE plpgsql
+AS
+$$
+DECLARE
+  _rows_updated integer;
+BEGIN
+  UPDATE beckett.subscriptions
+  SET name = _new_name
+  WHERE group_name = _group_name
+  AND name = _name;
+
+  LOOP
+    UPDATE beckett.checkpoints
+    SET name = _new_name
+    WHERE id IN (
+      SELECT id
+      FROM beckett.checkpoints
+      WHERE group_name = _group_name
+      AND name = _name
+      LIMIT 500
+    );
+
+    GET DIAGNOSTICS _rows_updated = ROW_COUNT;
+    EXIT WHEN _rows_updated = 0;
+  END LOOP;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION beckett.replay_subscription(
+  _group_name text,
+  _name text
+)
+  RETURNS void
+  LANGUAGE plpgsql
+AS
+$$
+DECLARE
+  _replay_target_position bigint;
+  _rows_updated integer;
+BEGIN
+  SELECT coalesce(max(m.global_position), 0)
+  INTO _replay_target_position
+  FROM beckett.checkpoints c
+  INNER JOIN beckett.messages_active m ON c.stream_name = m.stream_name AND c.stream_version = m.stream_position
+  WHERE c.group_name = _group_name
+  AND c.name = _name;
+
+  LOOP
+    UPDATE beckett.checkpoints
+    SET stream_position = 0
+    WHERE id IN (
+      SELECT id
+      FROM beckett.checkpoints
+      WHERE group_name = _group_name
+      AND name = _name
+      AND stream_position > 0
+      LIMIT 500
+    );
+
+    GET DIAGNOSTICS _rows_updated = ROW_COUNT;
+    EXIT WHEN _rows_updated = 0;
+  END LOOP;
+
+  UPDATE beckett.subscriptions
+  SET status = 'replay',
+      replay_target_position = _replay_target_position
+  WHERE group_name = _group_name
+  AND name = _name;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION beckett.reset_subscription(
+  _group_name text,
+  _name text
+)
+  RETURNS void
+  LANGUAGE plpgsql
+AS
+$$
+DECLARE
+  _rows_deleted integer;
+BEGIN
+  LOOP
+    DELETE FROM beckett.checkpoints
+    WHERE group_name = _group_name AND name = _name
+    AND id IN (
+      SELECT id FROM beckett.checkpoints
+      WHERE group_name = _group_name AND name = _name
+      LIMIT 500
+    );
+
+    GET DIAGNOSTICS _rows_deleted = ROW_COUNT;
+    EXIT WHEN _rows_deleted = 0;
+  END LOOP;
+
+  UPDATE beckett.subscriptions
+  SET status = 'uninitialized', replay_target_position = null
+  WHERE group_name = _group_name
+  AND name = _name;
+
+  INSERT INTO beckett.checkpoints (group_name, name, stream_name)
+  VALUES (_group_name, _name, '$initializing')
+  ON CONFLICT (group_name, name, stream_name) DO UPDATE
+    SET stream_version = 0,
+        stream_position = 0;
+END;
+$$;

--- a/src/Beckett.Dashboard/Subscriptions/Reset/ResetEndpoint.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Reset/ResetEndpoint.cs
@@ -1,0 +1,23 @@
+using Beckett.Database;
+
+namespace Beckett.Dashboard.Subscriptions.Reset;
+
+public static class ResetEndpoint
+{
+    public static async Task<IResult> Handle(
+        HttpContext context,
+        string groupName,
+        string name,
+        IPostgresDatabase database,
+        PostgresOptions options,
+        CancellationToken cancellationToken
+    )
+    {
+        await database.Execute(new ResetQuery(groupName, name), cancellationToken);
+
+        context.Response.Headers.Append("HX-Refresh", new StringValues("true"));
+        context.Response.Headers.Append("HX-Trigger", new StringValues("subscription_reset"));
+
+        return Results.Ok();
+    }
+}

--- a/src/Beckett.Dashboard/Subscriptions/Reset/ResetQuery.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Reset/ResetQuery.cs
@@ -1,0 +1,32 @@
+using Beckett.Database;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace Beckett.Dashboard.Subscriptions.Reset;
+
+public class ResetQuery(
+    string groupName,
+    string name
+) : IPostgresDatabaseQuery<int>
+{
+    public async Task<int> Execute(NpgsqlCommand command, CancellationToken cancellationToken)
+    {
+        //language=sql
+        const string sql = "SELECT beckett.reset_subscription($1, $2), pg_notify('beckett:subscriptions:reset', $1);";
+
+        command.CommandText = Query.Build(nameof(ResetQuery), sql, out var prepare);
+
+        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
+        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text });
+
+        if (prepare)
+        {
+            await command.PrepareAsync(cancellationToken);
+        }
+
+        command.Parameters[0].Value = groupName;
+        command.Parameters[1].Value = name;
+
+        return await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+}

--- a/src/Beckett.Dashboard/Subscriptions/Routes.cs
+++ b/src/Beckett.Dashboard/Subscriptions/Routes.cs
@@ -1,6 +1,7 @@
 using Beckett.Dashboard.Subscriptions.Groups;
 using Beckett.Dashboard.Subscriptions.Pause;
 using Beckett.Dashboard.Subscriptions.Replay;
+using Beckett.Dashboard.Subscriptions.Reset;
 using Beckett.Dashboard.Subscriptions.Resume;
 using Beckett.Dashboard.Subscriptions.Subscription;
 using Beckett.Dashboard.Subscriptions.Subscriptions;
@@ -18,6 +19,7 @@ public class Routes : IConfigureRoutes
         routes.MapGet("/{groupName}/{name}", SubscriptionEndpoint.Handle);
         routes.MapPost("/{groupName}/{name}/pause", PauseEndpoint.Handle).DisableAntiforgery();
         routes.MapPost("/{groupName}/{name}/replay", ReplayEndpoint.Handle).DisableAntiforgery();
+        routes.MapPost("/{groupName}/{name}/reset", ResetEndpoint.Handle).DisableAntiforgery();
         routes.MapPost("/{groupName}/{name}/resume", ResumeEndpoint.Handle).DisableAntiforgery();
     }
 }

--- a/src/Beckett.Dashboard/Subscriptions/Subscription/Subscription.razor
+++ b/src/Beckett.Dashboard/Subscriptions/Subscription/Subscription.razor
@@ -8,6 +8,9 @@
   document.body.addEventListener("subscription_replay_started", function () {
     alert('Subscription replay started successfully');
   });
+  document.body.addEventListener("subscription_reset", function () {
+    alert('Subscription reset successfully');
+  });
 </script>
 
 <nav style="--bs-breadcrumb-divider: '>';" class="bg-body-tertiary mt-2" aria-label="breadcrumb">
@@ -82,6 +85,16 @@
                     hx-confirm="Are you sure you want to replay this subscription?"
                     hx-on::response-error="alert('Unable to replay subscription at this time - please try again later')">
               Replay
+            </button>
+          }
+          @if (Model.Details.Status != SubscriptionStatus.Uninitialized)
+          {
+            <button class="btn btn-danger ms-2"
+                    title="Reset Subscription"
+                    hx-post="@Dashboard.Prefix/subscriptions/@Model.Details.GroupName/@Model.Details.Name/reset"
+                    hx-confirm="Are you sure you want to reset this subscription?"
+                    hx-on::response-error="alert('Unable to reset subscription at this time - please try again later')">
+              Reset
             </button>
           }
         </div>

--- a/src/Beckett/Subscriptions/Initialization/GroupSubscriptionInitializer.cs
+++ b/src/Beckett/Subscriptions/Initialization/GroupSubscriptionInitializer.cs
@@ -1,0 +1,32 @@
+using System.Threading.Channels;
+using Beckett.Database;
+using Beckett.Storage;
+using Microsoft.Extensions.Logging;
+
+namespace Beckett.Subscriptions.Initialization;
+
+public class GroupSubscriptionInitializer(
+    SubscriptionGroup group,
+    Channel<UninitializedSubscriptionAvailable> channel,
+    IPostgresDatabase database,
+    IPostgresDataSource dataSource,
+    IMessageStorage messageStorage,
+    ILoggerFactory loggerFactory
+)
+{
+    public async Task Initialize(CancellationToken stoppingToken)
+    {
+        var tasks = Enumerable.Range(1, group.InitializationConcurrency).Select(
+            _ => new SubscriptionInitializer(
+                group,
+                channel,
+                database,
+                dataSource,
+                messageStorage,
+                loggerFactory.CreateLogger<SubscriptionInitializer>()
+            ).Initialize(stoppingToken)
+        ).ToArray();
+
+        await Task.WhenAll(tasks);
+    }
+}

--- a/src/Beckett/Subscriptions/Initialization/GroupSubscriptionInitializerHost.cs
+++ b/src/Beckett/Subscriptions/Initialization/GroupSubscriptionInitializerHost.cs
@@ -1,0 +1,42 @@
+using Beckett.Database;
+using Beckett.Storage;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Beckett.Subscriptions.Initialization;
+
+public class GroupSubscriptionInitializerHost(
+    BeckettOptions options,
+    ISubscriptionInitializerChannel channel,
+    IPostgresDatabase database,
+    IPostgresDataSource dataSource,
+    IMessageStorage messageStorage,
+    ILoggerFactory loggerFactory
+) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!options.Subscriptions.InitializationEnabled)
+        {
+            return;
+        }
+
+        var groupSubscriptionInitializers = options.Subscriptions.Groups.Select(Build);
+
+        var tasks = groupSubscriptionInitializers.Select(x => x.Initialize(stoppingToken)).ToArray();
+
+        await Task.WhenAll(tasks);
+    }
+
+    private GroupSubscriptionInitializer Build(SubscriptionGroup group)
+    {
+        return new GroupSubscriptionInitializer(
+            group,
+            channel.For(group),
+            database,
+            dataSource,
+            messageStorage,
+            loggerFactory
+        );
+    }
+}

--- a/src/Beckett/Subscriptions/Initialization/ISubscriptionInitializer.cs
+++ b/src/Beckett/Subscriptions/Initialization/ISubscriptionInitializer.cs
@@ -1,6 +1,0 @@
-namespace Beckett.Subscriptions.Initialization;
-
-public interface ISubscriptionInitializer
-{
-    Task Initialize(CancellationToken cancellationToken);
-}

--- a/src/Beckett/Subscriptions/Initialization/ISubscriptionInitializerChannel.cs
+++ b/src/Beckett/Subscriptions/Initialization/ISubscriptionInitializerChannel.cs
@@ -1,0 +1,41 @@
+using System.Threading.Channels;
+
+namespace Beckett.Subscriptions.Initialization;
+
+public interface ISubscriptionInitializerChannel
+{
+    void Notify(SubscriptionGroup group);
+
+    Channel<UninitializedSubscriptionAvailable> For(SubscriptionGroup group);
+}
+
+public class SubscriptionInitializerChannel(BeckettOptions options)
+    : ISubscriptionInitializerChannel
+{
+    private readonly Dictionary<string, Channel<UninitializedSubscriptionAvailable>> _channels = BuildChannels(options);
+
+    public void Notify(SubscriptionGroup group)
+    {
+        if (!_channels.TryGetValue(group.Name, out var channel))
+        {
+            return;
+        }
+
+        channel.Writer.TryWrite(UninitializedSubscriptionAvailable.Instance);
+    }
+
+    public Channel<UninitializedSubscriptionAvailable> For(SubscriptionGroup group) => _channels[group.Name];
+
+    private static Dictionary<string, Channel<UninitializedSubscriptionAvailable>> BuildChannels(BeckettOptions options)
+    {
+        return options.Subscriptions.Groups.ToDictionary(
+            group => group.Name,
+            group => Channel.CreateBounded<UninitializedSubscriptionAvailable>(group.InitializationConcurrency * 2)
+        );
+    }
+}
+
+public readonly struct UninitializedSubscriptionAvailable
+{
+    public static UninitializedSubscriptionAvailable Instance { get; } = new();
+}

--- a/src/Beckett/Subscriptions/NotificationHandlers/SubscriptionResetNotificationHandler.cs
+++ b/src/Beckett/Subscriptions/NotificationHandlers/SubscriptionResetNotificationHandler.cs
@@ -1,0 +1,41 @@
+using Beckett.Database.Notifications;
+using Beckett.Subscriptions.Initialization;
+using Microsoft.Extensions.Logging;
+
+namespace Beckett.Subscriptions.NotificationHandlers;
+
+public class SubscriptionResetNotificationHandler(
+    ISubscriptionInitializerChannel channel,
+    BeckettOptions options,
+    ILogger<SubscriptionResetNotificationHandler> logger
+) : IPostgresNotificationHandler
+{
+    public string Channel => "beckett:subscriptions:reset";
+
+    public void Handle(string payload, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var group = options.Subscriptions.Groups.FirstOrDefault(x => x.Name == payload);
+
+            if (group == null)
+            {
+                return;
+            }
+
+            logger.ReceivedSubscriptionResetNotification(group.Name);
+
+            channel.Notify(group);
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Error handling subscription reset notification");
+        }
+    }
+}
+
+public static partial class Log
+{
+    [LoggerMessage(0, LogLevel.Information, "Received subscription reset notification for group {GroupName}")]
+    public static partial void ReceivedSubscriptionResetNotification(this ILogger logger, string groupName);
+}

--- a/src/Beckett/Subscriptions/ServiceCollectionExtensions.cs
+++ b/src/Beckett/Subscriptions/ServiceCollectionExtensions.cs
@@ -17,7 +17,7 @@ public static class ServiceCollectionExtensions
             return;
         }
 
-        services.AddSingleton<ISubscriptionInitializer, SubscriptionInitializer>();
+        services.AddSingleton<ISubscriptionInitializerChannel, SubscriptionInitializerChannel>();
 
         services.AddSingleton<IGlobalStreamNotificationChannel, GlobalStreamNotificationChannel>();
 
@@ -29,7 +29,11 @@ public static class ServiceCollectionExtensions
 
         services.AddSingleton<IPostgresNotificationHandler, GlobalStreamNotificationHandler>();
 
+        services.AddSingleton<IPostgresNotificationHandler, SubscriptionResetNotificationHandler>();
+
         services.AddHostedService<BootstrapSubscriptions>();
+
+        services.AddHostedService<GroupSubscriptionInitializerHost>();
 
         services.AddHostedService<GlobalStreamConsumerHost>();
 

--- a/src/Beckett/Subscriptions/SubscriptionGroup.cs
+++ b/src/Beckett/Subscriptions/SubscriptionGroup.cs
@@ -32,6 +32,20 @@ public class SubscriptionGroup(string groupName)
     public TimeSpan GlobalStreamPollingInterval { get; set; } = TimeSpan.FromSeconds(10);
 
     /// <summary>
+    /// Configure the batch size used when initializing subscriptions. This is the number of messages to read per batch
+    /// from the global stream while discovering streams and creating checkpoints for them. Setting this to a higher
+    /// number allows initialization to proceed more quickly for a large message store, at the expense of additional
+    /// overhead reading from it that could affect the performance of the application otherwise. Defaults to 1000.
+    /// </summary>
+    public int InitializationBatchSize { get; set; } = 1000;
+
+    /// <summary>
+    /// Configure the number of concurrent subscriptions Beckett can initialize at one time per host process.
+    /// Defaults to 5.
+    /// </summary>
+    public int InitializationConcurrency { get; set; } = 5;
+
+    /// <summary>
     /// Configure the timeout for checkpoint and retry reservations that occur while processing them. When a checkpoint
     /// or retry is available for processing, Beckett reserves it for the requesting consumer. The consumer processes it
     /// and no matter the outcome once complete releases the reservation. If the consumer fails to release the

--- a/src/Beckett/Subscriptions/SubscriptionOptions.cs
+++ b/src/Beckett/Subscriptions/SubscriptionOptions.cs
@@ -11,18 +11,9 @@ public class SubscriptionOptions
     public bool Enabled { get; set; }
 
     /// <summary>
-    /// Configure the batch size used when initializing subscriptions. This is the number of messages to read per batch
-    /// from the global stream while discovering streams and creating checkpoints for them. Setting this to a higher
-    /// number allows initialization to proceed more quickly for a large message store, at the expense of additional
-    /// overhead reading from it that could affect the performance of the application otherwise. Defaults to 1000.
+    /// Configure whether subscription initialization is enabled on this host.
     /// </summary>
-    public int InitializationBatchSize { get; set; } = 1000;
-
-    /// <summary>
-    /// Configure the number of concurrent subscriptions Beckett can initialize at one time per host process.
-    /// Defaults to 5.
-    /// </summary>
-    public int InitializationConcurrency { get; set; } = 5;
+    public bool InitializationEnabled { get; set; } = true;
 
     /// <summary>
     /// Control whether this host processes all subscriptions, active-only, or replay-only. An example of where this


### PR DESCRIPTION
- handle subscription initialization async - once subscriptions are bootstrapped the host can start processing new work while initialization happens asynchronously
- add reset button to dashboard with notification so that initialization/replay starts immediately vs after next restart of host(s)
- add official subscription management functions that can be used in migrations
  - dashboard has dependencies on these as well