### PR TITLE
Subscription Initialization - Resiliency

### DIFF
--- a/src/Beckett/Subscriptions/Initialization/ISubscriptionInitializerChannel.cs
+++ b/src/Beckett/Subscriptions/Initialization/ISubscriptionInitializerChannel.cs
@@ -21,7 +21,10 @@ public class SubscriptionInitializerChannel(BeckettOptions options)
             return;
         }
 
-        channel.Writer.TryWrite(UninitializedSubscriptionAvailable.Instance);
+        for (var i = 0; i < group.InitializationConcurrency; i++)
+        {
+            channel.Writer.TryWrite(UninitializedSubscriptionAvailable.Instance);
+        }
     }
 
     public Channel<UninitializedSubscriptionAvailable> For(SubscriptionGroup group) => _channels[group.Name];
@@ -30,7 +33,7 @@ public class SubscriptionInitializerChannel(BeckettOptions options)
     {
         return options.Subscriptions.Groups.ToDictionary(
             group => group.Name,
-            group => Channel.CreateBounded<UninitializedSubscriptionAvailable>(group.InitializationConcurrency * 2)
+            group => Channel.CreateBounded<UninitializedSubscriptionAvailable>(group.InitializationConcurrency)
         );
     }
 }

--- a/src/Beckett/Subscriptions/Services/BootstrapSubscriptions.cs
+++ b/src/Beckett/Subscriptions/Services/BootstrapSubscriptions.cs
@@ -140,10 +140,7 @@ public class BootstrapSubscriptions(
 
         await transaction.CommitAsync(stoppingToken);
 
-        for (var i = 0; i < checkpoints.Count; i++)
-        {
-            subscriptionInitializerChannel.Notify(group);
-        }
+        subscriptionInitializerChannel.Notify(group);
     }
 
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;


### PR DESCRIPTION
- subscription initializer should continue working until there's nothing left
  - group is notified, all initializers for group are activated and then continue processing until all subscriptions are initialized for group
  - if a reset comes in from the UI then the same process happens
  - task stays running waiting for notifications delivered via channel